### PR TITLE
syscall: lookup_slot_hash

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -7,6 +7,7 @@ pub use self::{
     sysvar::{
         SyscallGetClockSysvar, SyscallGetEpochRewardsSysvar, SyscallGetEpochScheduleSysvar,
         SyscallGetFeesSysvar, SyscallGetLastRestartSlotSysvar, SyscallGetRentSysvar,
+        SyscallLookupSlotHash,
     },
 };
 #[allow(deprecated)]
@@ -360,6 +361,7 @@ pub fn create_program_runtime_environment_v1<'a>(
         SyscallGetFeesSysvar::vm,
     )?;
     result.register_function_hashed(*b"sol_get_rent_sysvar", SyscallGetRentSysvar::vm)?;
+    result.register_function_hashed(*b"sol_syscall_lookup_slot_hash", SyscallLookupSlotHash::vm)?;
 
     register_feature_gated_function!(
         result,

--- a/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -1,4 +1,7 @@
-use super::*;
+use {
+    super::*,
+    solana_sdk::{hash::Hash, sysvar::slot_hashes::SlotHashes},
+};
 
 fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
     sysvar: Result<Arc<T>, InstructionError>,
@@ -18,6 +21,30 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
 
     let sysvar: Arc<T> = sysvar?;
     *var = T::clone(sysvar.as_ref());
+
+    Ok(SUCCESS)
+}
+
+fn syscall_lookup_slot_hash(
+    slot_hashes_sysvar: Result<Arc<SlotHashes>, InstructionError>,
+    var_addr: u64,
+    slot: u64,
+    check_aligned: bool,
+    memory_mapping: &mut MemoryMapping,
+    invoke_context: &mut InvokeContext,
+) -> Result<u64, Error> {
+    consume_compute_meter(
+        invoke_context,
+        invoke_context
+            .get_compute_budget()
+            .sysvar_base_cost
+            .saturating_add(size_of::<Hash>() as u64),
+    )?;
+
+    let slot_hashes_sysvar: Arc<SlotHashes> = slot_hashes_sysvar?;
+
+    let var = translate_type_mut::<Option<Hash>>(memory_mapping, var_addr, check_aligned)?;
+    *var = slot_hashes_sysvar.get(&slot).cloned();
 
     Ok(SUCCESS)
 }
@@ -150,6 +177,29 @@ declare_builtin_function!(
         get_sysvar(
             invoke_context.get_sysvar_cache().get_last_restart_slot(),
             var_addr,
+            invoke_context.get_check_aligned(),
+            memory_mapping,
+            invoke_context,
+        )
+    }
+);
+
+declare_builtin_function!(
+    /// Lookup a slot from the Slot Hashes sysvar
+    SyscallLookupSlotHash,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        var_addr: u64,
+        slot: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        syscall_lookup_slot_hash(
+            invoke_context.get_sysvar_cache().get_slot_hashes(),
+            var_addr,
+            slot,
             invoke_context.get_check_aligned(),
             memory_mapping,
             invoke_context,

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -61,6 +61,9 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_last_restart_slot(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
+    fn sol_syscall_lookup_slot_hash(&self, _var_addr: *mut u8, _slot: u64) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
     /// # Safety
     unsafe fn sol_memcpy(&self, dst: *mut u8, src: *const u8, n: usize) {
         // cannot be overlapping
@@ -169,6 +172,13 @@ pub(crate) fn sol_get_last_restart_slot(var_addr: *mut u8) -> u64 {
         .read()
         .unwrap()
         .sol_get_last_restart_slot(var_addr)
+}
+
+pub(crate) fn sol_syscall_lookup_slot_hash(var_addr: *mut u8, slot: u64) -> u64 {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_syscall_lookup_slot_hash(var_addr, slot)
 }
 
 pub(crate) fn sol_memcpy(dst: *mut u8, src: *const u8, n: usize) {

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -72,6 +72,7 @@ define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
 define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_syscall_lookup_slot_hash(addr: *mut u8, slot: u64) -> u64);
 
 #[cfg(target_feature = "static-syscalls")]
 pub const fn sys_hash(name: &str) -> usize {


### PR DESCRIPTION
[DRAFT]: Example of a new syscall `SlotHashes::lookup_slot_hash(slot: &Slot) -> Option<Hash>` which offloads the binary lookup to the syscall.

Snippet of usage in a test program:

```rust
use solana_program::{
    account_info::AccountInfo,
    entrypoint::ProgramResult,
    msg,
    pubkey::Pubkey,
    slot_hashes::{SlotHashes, MAX_ENTRIES},
    sysvar::slot_hashes::SyscallLookupSlotHash,
};

solana_program::declare_id!("CSi7jrVMN8ipLueDRt1Qx49fnrXT26ub4Tu9v6uq4oeB");

solana_program::entrypoint!(process_instruction);

fn process_instruction(
    _program_id: &Pubkey,
    _accounts: &[AccountInfo],
    _instruction_data: &[u8],
) -> ProgramResult {
    // 512 should be the unique hash. Last one should be `None`.
    for i in 509..514 {
        if let Some(hash) = <SlotHashes as SyscallLookupSlotHash>::lookup_slot_hash(&i)? {
            msg!("Slot: {}, Hash: {}", i, hash);
        } else {
            msg!("Slot: {}, Hash: None", i);
        }
    }

    // See how many times we can do it without busting compute.
    let mut chunk = 20;
    for i in 0..(MAX_ENTRIES as u64) {
        let _ = <SlotHashes as SyscallLookupSlotHash>::lookup_slot_hash(&i)?;
        if i == chunk {
            msg!("Reached iteration: {}", i);
            chunk += 20;
        }
    }

    Ok(())
}

```