### PR TITLE
syscall: lookup_slot_hash_position

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -7,6 +7,7 @@ pub use self::{
     sysvar::{
         SyscallGetClockSysvar, SyscallGetEpochRewardsSysvar, SyscallGetEpochScheduleSysvar,
         SyscallGetFeesSysvar, SyscallGetLastRestartSlotSysvar, SyscallGetRentSysvar,
+        SyscallLookupSlotHashPosition,
     },
 };
 #[allow(deprecated)]
@@ -360,6 +361,10 @@ pub fn create_program_runtime_environment_v1<'a>(
         SyscallGetFeesSysvar::vm,
     )?;
     result.register_function_hashed(*b"sol_get_rent_sysvar", SyscallGetRentSysvar::vm)?;
+    result.register_function_hashed(
+        *b"sol_syscall_lookup_slot_hash_position",
+        SyscallLookupSlotHashPosition::vm,
+    )?;
 
     register_feature_gated_function!(
         result,

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -61,6 +61,9 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_last_restart_slot(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
+    fn sol_syscall_lookup_slot_hash_position(&self, _var_addr: *mut u8, _slot: u64) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
     /// # Safety
     unsafe fn sol_memcpy(&self, dst: *mut u8, src: *const u8, n: usize) {
         // cannot be overlapping
@@ -169,6 +172,13 @@ pub(crate) fn sol_get_last_restart_slot(var_addr: *mut u8) -> u64 {
         .read()
         .unwrap()
         .sol_get_last_restart_slot(var_addr)
+}
+
+pub(crate) fn sol_syscall_lookup_slot_hash_position(var_addr: *mut u8, slot: u64) -> u64 {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_syscall_lookup_slot_hash_position(var_addr, slot)
 }
 
 pub(crate) fn sol_memcpy(dst: *mut u8, src: *const u8, n: usize) {

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -72,6 +72,7 @@ define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
 define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_syscall_lookup_slot_hash_position(addr: *mut u8, slot: u64) -> u64);
 
 #[cfg(target_feature = "static-syscalls")]
 pub const fn sys_hash(name: &str) -> usize {


### PR DESCRIPTION
[DRAFT]: Example of a new syscall `SlotHashes::lookup_slot_hash_position(slot: &Slot) -> Option<usize>` which offloads the binary lookup to the syscall.

Snippet of usage in a test program:

```rust
use solana_program::{
    account_info::AccountInfo, entrypoint::ProgramResult, program_error::ProgramError,
    pubkey::Pubkey, slot_hashes::SlotHashes, sysvar::slot_hashes::SyscallLookupSlotHashPosition,
};

solana_program::declare_id!("CSi7jrVMN8ipLueDRt1Qx49fnrXT26ub4Tu9v6uq4oeB");

solana_program::entrypoint!(process_instruction);

fn process_instruction(
    _program_id: &Pubkey,
    _accounts: &[AccountInfo],
    _instruction_data: &[u8],
) -> ProgramResult {
    // Tests skipped 10 slots and added 5 more hashes.

    // We should see slot 526 at position 0.
    if let Some(position) =
        <SlotHashes as SyscallLookupSlotHashPosition>::lookup_slot_hash_position(&526)?
    {
        if position != 0 {
            return Err(ProgramError::InvalidArgument);
        }
    }

    // We should see slot 522 at position 4.
    if let Some(position) =
        <SlotHashes as SyscallLookupSlotHashPosition>::lookup_slot_hash_position(&522)?
    {
        if position != 4 {
            return Err(ProgramError::InvalidArgument);
        }
    }

    // We should _not_ see slot 521.
    if <SlotHashes as SyscallLookupSlotHashPosition>::lookup_slot_hash_position(&521)?.is_some() {
        return Err(ProgramError::InvalidArgument);
    }

    // We should _not_ see slot 512.
    if <SlotHashes as SyscallLookupSlotHashPosition>::lookup_slot_hash_position(&512)?.is_some() {
        return Err(ProgramError::InvalidArgument);
    }

    // We should see slot 521 at position 5.
    if let Some(position) =
        <SlotHashes as SyscallLookupSlotHashPosition>::lookup_slot_hash_position(&521)?
    {
        if position != 5 {
            return Err(ProgramError::InvalidArgument);
        }
    }

    Ok(())
}

```