### PR TITLE
syscall: get_slots

### DIFF
--- a/programs/bpf_loader/src/syscalls/mod.rs
+++ b/programs/bpf_loader/src/syscalls/mod.rs
@@ -7,6 +7,7 @@ pub use self::{
     sysvar::{
         SyscallGetClockSysvar, SyscallGetEpochRewardsSysvar, SyscallGetEpochScheduleSysvar,
         SyscallGetFeesSysvar, SyscallGetLastRestartSlotSysvar, SyscallGetRentSysvar,
+        SyscallGetSlots,
     },
 };
 #[allow(deprecated)]
@@ -360,6 +361,7 @@ pub fn create_program_runtime_environment_v1<'a>(
         SyscallGetFeesSysvar::vm,
     )?;
     result.register_function_hashed(*b"sol_get_rent_sysvar", SyscallGetRentSysvar::vm)?;
+    result.register_function_hashed(*b"sol_syscall_get_slots", SyscallGetSlots::vm)?;
 
     register_feature_gated_function!(
         result,

--- a/programs/bpf_loader/src/syscalls/sysvar.rs
+++ b/programs/bpf_loader/src/syscalls/sysvar.rs
@@ -1,4 +1,7 @@
-use super::*;
+use {
+    super::*,
+    solana_sdk::{clock::Slot, hash::Hash, sysvar::slot_hashes::SlotHashes},
+};
 
 fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
     sysvar: Result<Arc<T>, InstructionError>,
@@ -18,6 +21,31 @@ fn get_sysvar<T: std::fmt::Debug + Sysvar + SysvarId + Clone>(
 
     let sysvar: Arc<T> = sysvar?;
     *var = T::clone(sysvar.as_ref());
+
+    Ok(SUCCESS)
+}
+
+fn syscall_get_slots(
+    slot_hashes_sysvar: Result<Arc<SlotHashes>, InstructionError>,
+    var_addr: u64,
+    check_aligned: bool,
+    memory_mapping: &mut MemoryMapping,
+    invoke_context: &mut InvokeContext,
+) -> Result<u64, Error> {
+    let slot_hashes_sysvar: Arc<SlotHashes> = slot_hashes_sysvar?;
+    let slot_hashes = slot_hashes_sysvar.slot_hashes();
+
+    let compute_size = size_of::<Slot>().saturating_mul(slot_hashes.len()) as u64;
+    consume_compute_meter(
+        invoke_context,
+        invoke_context
+            .get_compute_budget()
+            .sysvar_base_cost
+            .saturating_add(compute_size),
+    )?;
+
+    let var = translate_type_mut::<&[Slot]>(memory_mapping, var_addr, check_aligned)?;
+    *var = slot_hashes.iter().map(|(slot, _hash)| *slot).collect();
 
     Ok(SUCCESS)
 }
@@ -149,6 +177,28 @@ declare_builtin_function!(
     ) -> Result<u64, Error> {
         get_sysvar(
             invoke_context.get_sysvar_cache().get_last_restart_slot(),
+            var_addr,
+            invoke_context.get_check_aligned(),
+            memory_mapping,
+            invoke_context,
+        )
+    }
+);
+
+declare_builtin_function!(
+    /// Get all slots from the Slot Hashes sysvar
+    SyscallGetSlots,
+    fn rust(
+        invoke_context: &mut InvokeContext,
+        var_addr: u64,
+        _arg2: u64,
+        _arg3: u64,
+        _arg4: u64,
+        _arg5: u64,
+        memory_mapping: &mut MemoryMapping,
+    ) -> Result<u64, Error> {
+        syscall_get_slots(
+            invoke_context.get_sysvar_cache().get_slot_hashes(),
             var_addr,
             invoke_context.get_check_aligned(),
             memory_mapping,

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -61,6 +61,9 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_last_restart_slot(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
+    fn sol_syscall_get_slots(&self, _var_addr: *mut u8) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
     /// # Safety
     unsafe fn sol_memcpy(&self, dst: *mut u8, src: *const u8, n: usize) {
         // cannot be overlapping
@@ -169,6 +172,13 @@ pub(crate) fn sol_get_last_restart_slot(var_addr: *mut u8) -> u64 {
         .read()
         .unwrap()
         .sol_get_last_restart_slot(var_addr)
+}
+
+pub(crate) fn sol_syscall_get_slots(var_addr: *mut u8) -> u64 {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_syscall_get_slots(var_addr)
 }
 
 pub(crate) fn sol_memcpy(dst: *mut u8, src: *const u8, n: usize) {

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -72,6 +72,7 @@ define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
 define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_syscall_get_slots(addr: *mut u8) -> u64);
 
 #[cfg(target_feature = "static-syscalls")]
 pub const fn sys_hash(name: &str) -> usize {

--- a/sdk/program/src/sysvar/slot_hashes.rs
+++ b/sdk/program/src/sysvar/slot_hashes.rs
@@ -46,7 +46,7 @@
 //! ```
 
 pub use crate::slot_hashes::SlotHashes;
-use crate::{account_info::AccountInfo, program_error::ProgramError, sysvar::Sysvar};
+use crate::{account_info::AccountInfo, clock::Slot, program_error::ProgramError, sysvar::Sysvar};
 
 crate::declare_sysvar_id!("SysvarS1otHashes111111111111111111111111111", SlotHashes);
 
@@ -59,6 +59,28 @@ impl Sysvar for SlotHashes {
     fn from_account_info(_account_info: &AccountInfo) -> Result<Self, ProgramError> {
         // This sysvar is too large to bincode::deserialize in-program
         Err(ProgramError::UnsupportedSysvar)
+    }
+}
+
+pub trait SyscallGetSlots {
+    fn get_slots<'a>() -> Result<&'a [Slot], ProgramError>;
+}
+
+impl SyscallGetSlots for SlotHashes {
+    fn get_slots<'a>() -> Result<&'a [Slot], ProgramError> {
+        let mut var: &[Slot] = &[];
+        let var_addr = &mut var as *mut _ as *mut u8;
+
+        #[cfg(target_os = "solana")]
+        let result = unsafe { crate::syscalls::sol_syscall_get_slots(var_addr) };
+
+        #[cfg(not(target_os = "solana"))]
+        let result = crate::program_stubs::sol_syscall_get_slots(var_addr);
+
+        match result {
+            crate::entrypoint::SUCCESS => Ok(var),
+            e => Err(e.into()),
+        }
     }
 }
 


### PR DESCRIPTION
[DRAFT]: Example of a new syscall `SlotHashes::get_slots() -> &[Slot]` which converts the list of `(Slot, Hash)` to just `Slot`.