### PR TITLE
WIP: Syscall Get-Sysvar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6672,6 +6672,7 @@ dependencies = [
  "solana-logger",
  "solana-sdk-macro",
  "static_assertions",
+ "test-case",
  "thiserror",
  "tiny-bip39",
  "wasm-bindgen",

--- a/program-test/tests/cpi.rs
+++ b/program-test/tests/cpi.rs
@@ -95,7 +95,7 @@ fn invoke_create_account(
     let payer_info = next_account_info(account_info_iter)?;
     let create_account_info = next_account_info(account_info_iter)?;
     let system_program_info = next_account_info(account_info_iter)?;
-    let rent = Rent::get()?;
+    let rent = Rent::load()?;
     let minimum_balance = rent.minimum_balance(MAX_PERMITTED_DATA_INCREASE);
     invoke(
         &system_instruction::create_account(

--- a/program-test/tests/sysvar.rs
+++ b/program-test/tests/sysvar.rs
@@ -15,13 +15,13 @@ fn sysvar_getter_process_instruction(
 ) -> ProgramResult {
     msg!("sysvar_getter");
 
-    let clock = Clock::get()?;
+    let clock = Clock::load()?;
     assert_eq!(42, clock.slot);
 
-    let epoch_schedule = EpochSchedule::get()?;
+    let epoch_schedule = EpochSchedule::load()?;
     assert_eq!(epoch_schedule, EpochSchedule::default());
 
-    let rent = Rent::get()?;
+    let rent = Rent::load()?;
     assert_eq!(rent, Rent::default());
 
     Ok(())
@@ -65,10 +65,10 @@ fn epoch_reward_sysvar_getter_process_instruction(
     // input[0] == 1 indicates the bank is in reward period.
     if input[0] == 0 {
         // epoch rewards sysvar should not exist for banks that are not in reward period
-        let epoch_rewards = EpochRewards::get();
+        let epoch_rewards = EpochRewards::load();
         assert!(epoch_rewards.is_err());
     } else {
-        let _epoch_rewards = EpochRewards::get()?;
+        let _epoch_rewards = EpochRewards::load()?;
     }
 
     Ok(())

--- a/program-test/tests/sysvar_last_restart_slot.rs
+++ b/program-test/tests/sysvar_last_restart_slot.rs
@@ -23,7 +23,7 @@ fn sysvar_last_restart_slot_process_instruction(
     assert_eq!(input.len(), 8);
     let expected_last_hardfork_slot = u64::from_le_bytes(input[0..8].try_into().unwrap());
 
-    let last_restart_slot = LastRestartSlot::get();
+    let last_restart_slot = LastRestartSlot::load();
     msg!("last restart slot: {:?}", last_restart_slot);
     assert_eq!(
         last_restart_slot,

--- a/sdk/program/Cargo.toml
+++ b/sdk/program/Cargo.toml
@@ -84,6 +84,7 @@ array-bytes = { workspace = true }
 assert_matches = { workspace = true }
 serde_json = { workspace = true }
 static_assertions = { workspace = true }
+test-case = { workspace = true }
 
 [build-dependencies]
 rustc_version = { workspace = true }

--- a/sdk/program/src/program_stubs.rs
+++ b/sdk/program/src/program_stubs.rs
@@ -61,6 +61,15 @@ pub trait SyscallStubs: Sync + Send {
     fn sol_get_last_restart_slot(&self, _var_addr: *mut u8) -> u64 {
         UNSUPPORTED_SYSVAR
     }
+    fn sol_get_sysvar(
+        &self,
+        _sysvar_id: *const u8,
+        _var_addr: *mut u8,
+        _length: u64,
+        _offset: u64,
+    ) -> u64 {
+        UNSUPPORTED_SYSVAR
+    }
     /// # Safety
     unsafe fn sol_memcpy(&self, dst: *mut u8, src: *const u8, n: usize) {
         // cannot be overlapping
@@ -169,6 +178,19 @@ pub(crate) fn sol_get_last_restart_slot(var_addr: *mut u8) -> u64 {
         .read()
         .unwrap()
         .sol_get_last_restart_slot(var_addr)
+}
+
+#[allow(dead_code)] // Removed in later commit.
+pub(crate) fn sol_get_sysvar(
+    sysvar_id: *const u8,
+    var_addr: *mut u8,
+    length: u64,
+    offset: u64,
+) -> u64 {
+    SYSCALL_STUBS
+        .read()
+        .unwrap()
+        .sol_get_sysvar(sysvar_id, var_addr, length, offset)
 }
 
 pub(crate) fn sol_memcpy(dst: *mut u8, src: *const u8, n: usize) {

--- a/sdk/program/src/syscalls/definitions.rs
+++ b/sdk/program/src/syscalls/definitions.rs
@@ -72,6 +72,7 @@ define_syscall!(fn sol_get_epoch_rewards_sysvar(addr: *mut u8) -> u64);
 define_syscall!(fn sol_poseidon(parameters: u64, endianness: u64, vals: *const u8, val_len: u64, hash_result: *mut u8) -> u64);
 define_syscall!(fn sol_remaining_compute_units() -> u64);
 define_syscall!(fn sol_alt_bn128_compression(op: u64, input: *const u8, input_size: u64, result: *mut u8) -> u64);
+define_syscall!(fn sol_get_sysvar(sysvar_id: *const u8, addr: *mut u8, length: u64, offset: u64) -> u64);
 
 #[cfg(target_feature = "static-syscalls")]
 pub const fn sys_hash(name: &str) -> usize {

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -212,6 +212,7 @@ pub trait Sysvar:
     ///
     /// Not all sysvars support this method. If not, it returns
     /// [`ProgramError::UnsupportedSysvar`].
+    #[deprecated(since = "2.0.0", note = "Please use `Sysvar::load`.")]
     fn get() -> Result<Self, ProgramError> {
         Err(ProgramError::UnsupportedSysvar)
     }

--- a/sdk/program/src/sysvar/mod.rs
+++ b/sdk/program/src/sysvar/mod.rs
@@ -84,6 +84,7 @@
 use {
     crate::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey},
     lazy_static::lazy_static,
+    std::alloc::{alloc, Layout},
 };
 
 pub mod clock;
@@ -214,6 +215,47 @@ pub trait Sysvar:
     fn get() -> Result<Self, ProgramError> {
         Err(ProgramError::UnsupportedSysvar)
     }
+
+    /// Load the sysvar directly from the runtime.
+    ///
+    /// This is the preferred way to load a sysvar. Calling this method does not
+    /// incur any deserialization overhead, and does not require the sysvar
+    /// account to be passed to the program.
+    fn load() -> Result<Self, ProgramError> {
+        let data = get_sysvar(&Self::id(), 0, Self::size_of() as u64)?;
+        bincode::deserialize(data).map_err(|_| ProgramError::InvalidArgument)
+    }
+}
+
+/// Handler for retrieving a slice of sysvar data from the `sol_get_sysvar`
+/// syscall.
+fn get_sysvar<'a>(sysvar_id: &Pubkey, offset: u64, length: u64) -> Result<&'a [u8], ProgramError> {
+    let sysvar_id = sysvar_id as *const _ as *const u8;
+
+    // Allocate the memory region for the sysvar data to be written to.
+    let var = unsafe {
+        let length = length as usize;
+        let layout = Layout::from_size_align(length, std::mem::align_of::<u8>())
+            .map_err(|_| ProgramError::InvalidArgument)?;
+        let ptr = alloc(layout);
+        if ptr.is_null() {
+            return Err(ProgramError::InvalidArgument);
+        }
+        std::slice::from_raw_parts_mut(ptr, length)
+    };
+
+    let var_addr = var as *mut _ as *mut u8;
+
+    #[cfg(target_os = "solana")]
+    let result = unsafe { crate::syscalls::sol_get_sysvar(sysvar_id, var_addr, offset, length) };
+
+    #[cfg(not(target_os = "solana"))]
+    let result = crate::program_stubs::sol_get_sysvar(sysvar_id, var_addr, offset, length);
+
+    match result {
+        crate::entrypoint::SUCCESS => Ok(var),
+        e => Err(e.into()),
+    }
 }
 
 /// Implements the [`Sysvar::get`] method for both SBF and host targets.
@@ -244,6 +286,7 @@ mod tests {
         super::*,
         crate::{clock::Epoch, program_error::ProgramError, pubkey::Pubkey},
         std::{cell::RefCell, rc::Rc},
+        test_case::test_case,
     };
 
     #[repr(C)]
@@ -295,5 +338,32 @@ mod tests {
         let mut small_data = vec![];
         account_info.data = Rc::new(RefCell::new(&mut small_data));
         assert_eq!(test_sysvar.to_account_info(&mut account_info), None);
+    }
+
+    // As long as we use a test sysvar ID and we're _not_ testing from a BPF
+    // context, the `sol_get_sysvar` syscall will always return
+    // `ProgramError::UnsupportedSysvar`, since the ID will not match any
+    // sysvars in the Sysvar Cache.
+    // Under this condition, we can test the pointer allocation by keying on
+    // `ProgramError::InvalidArgument`.
+    // Also, `offset` is only used in the syscall, _not_ the pointer
+    // allocation.
+    #[test_case(0)]
+    #[test_case(2)]
+    #[test_case(64)]
+    #[test_case(99)]
+    #[test_case(1024)]
+    #[test_case(1234)]
+    #[test_case(65_536)]
+    #[test_case(70_000)]
+    #[test_case(70_001)]
+    #[test_case(4_294_967_296)]
+    #[test_case(8_000_000_000)]
+    #[test_case(8_000_000_001)]
+    fn test_get_sysvar_alloc(length: u64) {
+        assert_eq!(
+            get_sysvar(&crate::sysvar::tests::id(), 0, length).unwrap_err(),
+            ProgramError::UnsupportedSysvar,
+        );
     }
 }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -785,6 +785,10 @@ pub mod deprecate_unused_legacy_vote_plumbing {
     solana_sdk::declare_id!("6Uf8S75PVh91MYgPQSHnjRAPQq6an5BDv9vomrCwDqLe");
 }
 
+pub mod enable_syscall_get_sysvar {
+    solana_sdk::declare_id!("6AQpnbUKwV1ikPXRcbPB2HRP8BWGg26WUdaqRum6ZB8Y");
+}
+
 lazy_static! {
     /// Map of feature identifiers to user-visible description
     pub static ref FEATURE_NAMES: HashMap<Pubkey, &'static str> = [
@@ -976,6 +980,7 @@ lazy_static! {
         (enable_chained_merkle_shreds::id(), "Enable chained Merkle shreds #34916"),
         (remove_rounding_in_fee_calculation::id(), "Removing unwanted rounding in fee calculation #34982"),
         (deprecate_unused_legacy_vote_plumbing::id(), "Deprecate unused legacy vote tx plumbing"),
+        (enable_syscall_get_sysvar::id(), "Enable syscall: sol_get_sysvar ### PR UNKNOWN ATM"),
         /*************** ADD NEW FEATURES HERE ***************/
     ]
     .iter()


### PR DESCRIPTION
### SIMD 0127 - Syscall: Get Sysvar

Here's everything we need besides the `SysvarCache` overhaul.

- SIMD compliance (with tests).
- Feature gate.
- Add `Sysvar::load` interface (with tests).
- Deprecate `Sysvar::get` interface.

From here we can build additional interfaces for different sysvars, such as
`SlotHashes` and `StakeHistory`, for retrieving specific information or
list-based entries.

cc @2501babe