### PR TITLE
Runtime: add `RentCollectorWithMetrics` wrapper type for SVM

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4448,9 +4448,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7682,6 +7682,7 @@ dependencies = [
 name = "solana-svm"
 version = "2.1.0"
 dependencies = [
+ "assert_matches",
  "bincode",
  "itertools 0.12.1",
  "lazy_static",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7748,6 +7748,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-svm-rent-collector"
+version = "2.1.0"
+dependencies = [
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-svm-transaction"
 version = "2.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7378,6 +7378,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-svm",
+ "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,6 +119,7 @@ members = [
     "streamer",
     "svm",
     "svm-conformance",
+    "svm-rent-collector",
     "svm-transaction",
     "svm/examples/paytube",
     "test-validator",
@@ -434,6 +435,7 @@ solana-streamer = { path = "streamer", version = "=2.1.0" }
 solana-svm = { path = "svm", version = "=2.1.0" }
 solana-svm-conformance = { path = "svm-conformance", version = "=2.1.0" }
 solana-svm-example-paytube = { path = "svm/examples/paytube", version = "=2.1.0" }
+solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.1.0" }
 solana-svm-transaction = { path = "svm-transaction", version = "=2.1.0" }
 solana-system-program = { path = "programs/system", version = "=2.1.0" }
 solana-test-validator = { path = "test-validator", version = "=2.1.0" }

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -2030,6 +2030,7 @@ pub struct ShrinkStats {
     alive_accounts: AtomicU64,
     accounts_loaded: AtomicU64,
     purged_zero_lamports: AtomicU64,
+    accounts_not_found_in_index: AtomicU64,
 }
 
 impl ShrinkStats {
@@ -2131,6 +2132,11 @@ impl ShrinkStats {
                 (
                     "purged_zero_lamports_count",
                     self.purged_zero_lamports.swap(0, Ordering::Relaxed),
+                    i64
+                ),
+                (
+                    "accounts_not_found_in_index",
+                    self.accounts_not_found_in_index.swap(0, Ordering::Relaxed),
                     i64
                 ),
             );
@@ -2337,6 +2343,13 @@ impl ShrinkAncientStats {
                 "purged_zero_lamports_count",
                 self.shrink_stats
                     .purged_zero_lamports
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "accounts_not_found_in_index",
+                self.shrink_stats
+                    .accounts_not_found_in_index
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
@@ -3928,6 +3941,10 @@ impl AccountsDb {
                         alive_accounts.add(ref_count, stored_account, slot_list);
                         alive += 1;
                     }
+                } else {
+                    stats
+                        .accounts_not_found_in_index
+                        .fetch_add(1, Ordering::Relaxed);
                 }
                 index += 1;
                 result

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -1959,6 +1959,7 @@ struct CleanAccountsStats {
     remove_dead_accounts_shrink_us: AtomicU64,
     clean_stored_dead_slots_us: AtomicU64,
     uncleaned_roots_slot_list_1: AtomicU64,
+    get_account_sizes_us: AtomicU64,
 }
 
 impl CleanAccountsStats {
@@ -3590,6 +3591,13 @@ impl AccountsDb {
                 "uncleaned_roots_slot_list_1",
                 self.clean_accounts_stats
                     .uncleaned_roots_slot_list_1
+                    .swap(0, Ordering::Relaxed),
+                i64
+            ),
+            (
+                "get_account_sizes_us",
+                self.clean_accounts_stats
+                    .get_account_sizes_us
                     .swap(0, Ordering::Relaxed),
                 i64
             ),
@@ -8043,20 +8051,25 @@ impl AccountsDb {
                     dead_slots.insert(*slot);
                 }
                 else {
-                    let mut offsets = offsets.iter().cloned().collect::<Vec<_>>();
-                    // sort so offsets are in order. This improves efficiency of loading the accounts.
-                    offsets.sort_unstable();
-                    let dead_bytes = store.accounts.get_account_sizes(&offsets).iter().sum();
-                    store.remove_accounts(dead_bytes, reset_accounts, offsets.len());
-                    if Self::is_shrinking_productive(*slot, &store)
-                        && self.is_candidate_for_shrink(&store)
-                    {
-                        // Checking that this single storage entry is ready for shrinking,
-                        // should be a sufficient indication that the slot is ready to be shrunk
-                        // because slots should only have one storage entry, namely the one that was
-                        // created by `flush_slot_cache()`.
-                        new_shrink_candidates.insert(*slot);
-                    }
+                    let (_, us) = measure_us!({
+                        let mut offsets = offsets.iter().cloned().collect::<Vec<_>>();
+                        // sort so offsets are in order. This improves efficiency of loading the accounts.
+                        offsets.sort_unstable();
+                        let dead_bytes = store.accounts.get_account_sizes(&offsets).iter().sum();
+                        store.remove_accounts(dead_bytes, reset_accounts, offsets.len());
+                        if Self::is_shrinking_productive(*slot, &store)
+                            && self.is_candidate_for_shrink(&store)
+                        {
+                            // Checking that this single storage entry is ready for shrinking,
+                            // should be a sufficient indication that the slot is ready to be shrunk
+                            // because slots should only have one storage entry, namely the one that was
+                            // created by `flush_slot_cache()`.
+                            new_shrink_candidates.insert(*slot);
+                        }
+                    });
+                    self.clean_accounts_stats
+                        .get_account_sizes_us
+                        .fetch_add(us, Ordering::Relaxed);
                 }
             }
         });

--- a/accounts-db/src/accounts_db.rs
+++ b/accounts-db/src/accounts_db.rs
@@ -3979,6 +3979,11 @@ impl AccountsDb {
         }
     }
 
+    #[cfg(feature = "dev-context-only-utils")]
+    pub fn set_storage_access(&mut self, storage_access: StorageAccess) {
+        self.storage_access = storage_access;
+    }
+
     /// Sort `accounts` by pubkey and removes all but the *last* of consecutive
     /// accounts in the vector with the same pubkey.
     ///

--- a/accounts-db/src/ancient_append_vecs.rs
+++ b/accounts-db/src/ancient_append_vecs.rs
@@ -696,11 +696,20 @@ impl AccountsDb {
             let slot = shrink_collect.slot;
 
             let shrink_in_progress = write_ancient_accounts.shrinks_in_progress.remove(&slot);
+
+            let mut reopen = false;
             if shrink_in_progress.is_none() {
                 dropped_roots.push(slot);
             } else {
-                self.reopen_storage_as_readonly_shrinking_in_progress_ok(slot);
+                // Remember that we need to 'reopen' the storage for this
+                // 'slot'. Note that it is not *safe* to reopen the storage for
+                // the 'slot' here, because 'shrink_in_progress' is still alive.
+                // Storage map may still point to the old storage and will be
+                // updated to point to the new storage, after we drop
+                // 'shrink_in_progress'.
+                reopen = true;
             }
+
             self.remove_old_stores_shrink(
                 &shrink_collect,
                 &self.shrink_ancient_stats.shrink_stats,
@@ -710,6 +719,11 @@ impl AccountsDb {
 
             // If the slot is dead, remove the need to shrink the storage as the storage entries will be purged.
             self.shrink_candidate_slots.lock().unwrap().remove(&slot);
+
+            if reopen {
+                // 'shrink_in_progress' is dead now. We can safely 'reopen' the new storage for 'slot'.
+                self.reopen_storage_as_readonly_shrinking_in_progress_ok(slot);
+            }
         }
         self.handle_dropped_roots_for_ancient(dropped_roots.into_iter());
         metrics.accumulate(&write_ancient_accounts.metrics);
@@ -1184,6 +1198,7 @@ pub mod tests {
                 },
                 ShrinkCollectRefs,
             },
+            accounts_file::StorageAccess,
             accounts_hash::AccountHash,
             accounts_index::UpsertReclaim,
             append_vec::{
@@ -1591,89 +1606,100 @@ pub mod tests {
         // or all slots shrunk so no roots or storages should be removed
         for in_shrink_candidate_slots in [false, true] {
             for all_slots_shrunk in [false, true] {
-                for num_slots in 0..3 {
-                    let (db, storages, slots, infos) = get_sample_storages(num_slots, None);
-                    let mut accounts_per_storage = infos
-                        .iter()
-                        .zip(
-                            storages
-                                .iter()
-                                .map(|store| db.get_unique_accounts_from_storage(store)),
-                        )
-                        .collect::<Vec<_>>();
+                for storage_access in [StorageAccess::Mmap, StorageAccess::File] {
+                    for num_slots in 0..3 {
+                        let (mut db, storages, slots, infos) = get_sample_storages(num_slots, None);
+                        db.set_storage_access(storage_access);
+                        let mut accounts_per_storage = infos
+                            .iter()
+                            .zip(
+                                storages
+                                    .iter()
+                                    .map(|store| db.get_unique_accounts_from_storage(store)),
+                            )
+                            .collect::<Vec<_>>();
 
-                    let alive_bytes = 1000;
-                    let accounts_to_combine = db.calc_accounts_to_combine(
-                        &mut accounts_per_storage,
-                        &default_tuning(),
-                        alive_bytes,
-                        IncludeManyRefSlots::Include,
-                    );
-                    let mut stats = ShrinkStatsSub::default();
-                    let mut write_ancient_accounts = WriteAncientAccounts::default();
+                        let alive_bytes = 1000;
+                        let accounts_to_combine = db.calc_accounts_to_combine(
+                            &mut accounts_per_storage,
+                            &default_tuning(),
+                            alive_bytes,
+                            IncludeManyRefSlots::Include,
+                        );
+                        let mut stats = ShrinkStatsSub::default();
+                        let mut write_ancient_accounts = WriteAncientAccounts::default();
 
-                    slots.clone().for_each(|slot| {
-                        db.add_root(slot);
-                        let storage = db.storage.get_slot_storage_entry(slot);
-                        assert!(storage.is_some());
-                        if in_shrink_candidate_slots {
-                            db.shrink_candidate_slots.lock().unwrap().insert(slot);
-                        }
-                    });
-
-                    let roots = db
-                        .accounts_index
-                        .roots_tracker
-                        .read()
-                        .unwrap()
-                        .alive_roots
-                        .get_all();
-                    assert_eq!(roots, slots.clone().collect::<Vec<_>>());
-
-                    if all_slots_shrunk {
-                        // make it look like each of the slots was shrunk
                         slots.clone().for_each(|slot| {
-                            write_ancient_accounts
-                                .shrinks_in_progress
-                                .insert(slot, db.get_store_for_shrink(slot, 1));
+                            db.add_root(slot);
+                            let storage = db.storage.get_slot_storage_entry(slot);
+                            assert!(storage.is_some());
+                            if in_shrink_candidate_slots {
+                                db.shrink_candidate_slots.lock().unwrap().insert(slot);
+                            }
+                        });
+
+                        let roots = db
+                            .accounts_index
+                            .roots_tracker
+                            .read()
+                            .unwrap()
+                            .alive_roots
+                            .get_all();
+                        assert_eq!(roots, slots.clone().collect::<Vec<_>>());
+
+                        if all_slots_shrunk {
+                            // make it look like each of the slots was shrunk
+                            slots.clone().for_each(|slot| {
+                                write_ancient_accounts
+                                    .shrinks_in_progress
+                                    .insert(slot, db.get_store_for_shrink(slot, 1));
+                            });
+                        }
+
+                        db.finish_combine_ancient_slots_packed_internal(
+                            accounts_to_combine,
+                            write_ancient_accounts,
+                            &mut stats,
+                        );
+
+                        slots.clone().for_each(|slot| {
+                            assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&slot));
+                        });
+
+                        let roots_after = db
+                            .accounts_index
+                            .roots_tracker
+                            .read()
+                            .unwrap()
+                            .alive_roots
+                            .get_all();
+
+                        assert_eq!(
+                            roots_after,
+                            if all_slots_shrunk {
+                                slots.clone().collect::<Vec<_>>()
+                            } else {
+                                vec![]
+                            },
+                            "all_slots_shrunk: {all_slots_shrunk}"
+                        );
+                        slots.for_each(|slot| {
+                            let storage = db.storage.get_slot_storage_entry(slot);
+                            if all_slots_shrunk {
+                                assert!(storage.is_some());
+                                // Here we use can_append() as a proxy to assert the backup storage of the accounts after shrinking.
+                                // When storage_access is set to `File`, after shrinking an ancient slot, the backup storage should be
+                                // open as File, which means can_append() will return false.
+                                // When storage_access is set to `Mmap`, backup storage is still Mmap, and can_append() will return true.
+                                assert_eq!(
+                                    storage.unwrap().accounts.can_append(),
+                                    storage_access == StorageAccess::Mmap
+                                );
+                            } else {
+                                assert!(storage.is_none());
+                            }
                         });
                     }
-
-                    db.finish_combine_ancient_slots_packed_internal(
-                        accounts_to_combine,
-                        write_ancient_accounts,
-                        &mut stats,
-                    );
-
-                    slots.clone().for_each(|slot| {
-                        assert!(!db.shrink_candidate_slots.lock().unwrap().contains(&slot));
-                    });
-
-                    let roots_after = db
-                        .accounts_index
-                        .roots_tracker
-                        .read()
-                        .unwrap()
-                        .alive_roots
-                        .get_all();
-
-                    assert_eq!(
-                        roots_after,
-                        if all_slots_shrunk {
-                            slots.clone().collect::<Vec<_>>()
-                        } else {
-                            vec![]
-                        },
-                        "all_slots_shrunk: {all_slots_shrunk}"
-                    );
-                    slots.for_each(|slot| {
-                        let storage = db.storage.get_slot_storage_entry(slot);
-                        if all_slots_shrunk {
-                            assert!(storage.is_some());
-                        } else {
-                            assert!(storage.is_none());
-                        }
-                    });
                 }
             }
         }

--- a/ci/upload-benchmark.sh
+++ b/ci/upload-benchmark.sh
@@ -69,13 +69,13 @@ fi
 
 while IFS= read -r line; do
 
-  if [[ $line =~ ^test\ (.*)\ \.\.\.\ bench:\ *([0-9,]+)\ ns\/iter\ \(\+\/-\ *([0-9,]+)\) ]]; then
+  if [[ $line =~ ^test\ (.*)\ \.\.\.\ bench:\ *([0-9,\.]+)\ ns\/iter\ \(\+\/-\ *([0-9,\.]+)\) ]]; then
     test_name="${BASH_REMATCH[1]}"
     ns_iter="${BASH_REMATCH[2]}"
     plus_minus="${BASH_REMATCH[3]}"
 
-    ns_iter=$(echo "$ns_iter" | tr -d ',')
-    plus_minus=$(echo "$plus_minus" | tr -d ',')
+    ns_iter=$(echo "$ns_iter" | tr -d ',' | cut -d'.' -f1)
+    plus_minus=$(echo "$plus_minus" | tr -d ',' | cut -d'.' -f1)
 
     datapoint="${INFLUX_MEASUREMENT},commit=${COMMIT_HASH},test_suite=${TEST_SUITE},name=${test_name} median=${ns_iter}i,deviation=${plus_minus}i"
     echo "datapoint: $datapoint"

--- a/clap-utils/src/compute_budget.rs
+++ b/clap-utils/src/compute_budget.rs
@@ -33,6 +33,7 @@ pub fn compute_unit_limit_arg<'a, 'b>() -> Arg<'a, 'b> {
         .help(COMPUTE_UNIT_LIMIT_ARG.help)
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum ComputeUnitLimit {
     /// Do not include a compute unit limit instruction, which will give the
     /// transaction a compute unit limit of:

--- a/cli/src/cluster_query.rs
+++ b/cli/src/cluster_query.rs
@@ -1471,6 +1471,7 @@ pub fn process_ping(
         let to = config.signers[0].pubkey();
         lamports = lamports.saturating_add(1);
 
+        let compute_unit_limit = ComputeUnitLimit::Default;
         let build_message = |lamports| {
             let ixs = vec![system_instruction::transfer(
                 &config.signers[0].pubkey(),
@@ -1479,7 +1480,7 @@ pub fn process_ping(
             )]
             .with_compute_unit_config(&ComputeUnitConfig {
                 compute_unit_price,
-                compute_unit_limit: ComputeUnitLimit::Default,
+                compute_unit_limit,
             });
             Message::new(&ixs, Some(&config.signers[0].pubkey()))
         };
@@ -1489,6 +1490,7 @@ pub fn process_ping(
             SpendAmount::Some(lamports),
             &blockhash,
             &config.signers[0].pubkey(),
+            compute_unit_limit,
             build_message,
             config.commitment,
         )?;

--- a/cli/src/feature.rs
+++ b/cli/src/feature.rs
@@ -10,7 +10,8 @@ use {
     console::style,
     serde::{Deserialize, Serialize},
     solana_clap_utils::{
-        fee_payer::*, hidden_unless_forced, input_parsers::*, input_validators::*, keypair::*,
+        compute_budget::ComputeUnitLimit, fee_payer::*, hidden_unless_forced, input_parsers::*,
+        input_validators::*, keypair::*,
     },
     solana_cli_output::{cli_version::CliVersion, QuietDisplay, VerboseDisplay},
     solana_remote_wallet::remote_wallet::RemoteWalletManager,
@@ -972,6 +973,7 @@ fn process_activate(
         SpendAmount::Some(rent),
         &blockhash,
         &fee_payer.pubkey(),
+        ComputeUnitLimit::Default,
         |lamports| {
             Message::new(
                 &feature::activate_with_lamports(&feature_id, &fee_payer.pubkey(), lamports),

--- a/cli/src/nonce.rs
+++ b/cli/src/nonce.rs
@@ -462,6 +462,7 @@ pub fn process_create_nonce_account(
 
     let nonce_authority = nonce_authority.unwrap_or_else(|| config.signers[0].pubkey());
 
+    let compute_unit_limit = ComputeUnitLimit::Default;
     let build_message = |lamports| {
         let ixs = if let Some(seed) = seed.clone() {
             create_nonce_account_with_seed(
@@ -475,7 +476,7 @@ pub fn process_create_nonce_account(
             .with_memo(memo)
             .with_compute_unit_config(&ComputeUnitConfig {
                 compute_unit_price,
-                compute_unit_limit: ComputeUnitLimit::Default,
+                compute_unit_limit,
             })
         } else {
             create_nonce_account(
@@ -487,7 +488,7 @@ pub fn process_create_nonce_account(
             .with_memo(memo)
             .with_compute_unit_config(&ComputeUnitConfig {
                 compute_unit_price,
-                compute_unit_limit: ComputeUnitLimit::Default,
+                compute_unit_limit,
             })
         };
         Message::new(&ixs, Some(&config.signers[0].pubkey()))
@@ -501,6 +502,7 @@ pub fn process_create_nonce_account(
         amount,
         &latest_blockhash,
         &config.signers[0].pubkey(),
+        compute_unit_limit,
         build_message,
         config.commitment,
     )?;

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -20,6 +20,7 @@ pub enum SpendAmount {
     All,
     Some(u64),
     RentExempt,
+    AllForAccountCreation { create_account_min_balance: u64 },
 }
 
 impl Default for SpendAmount {
@@ -166,7 +167,35 @@ where
 {
     let (fee, compute_unit_info) = match blockhash {
         Some(blockhash) => {
-            let mut dummy_message = build_message(0);
+            // If the from account is the same as the fee payer, it's impossible
+            // to give a correct amount for the simulation with `SpendAmount::All`
+            // or `SpendAmount::RentExempt`.
+            // To know how much to transfer, we need to know the transaction fee,
+            // but the transaction fee is dependent on the amount of compute
+            // units used, which requires simulation.
+            // To get around this limitation, we simulate against an amount of
+            // `0`, since there are few situations in which `SpendAmount` can
+            // be `All` or `RentExempt` *and also* the from account is the fee
+            // payer.
+            let lamports = if from_pubkey == fee_pubkey {
+                match amount {
+                    SpendAmount::Some(lamports) => lamports,
+                    SpendAmount::AllForAccountCreation {
+                        create_account_min_balance,
+                    } => create_account_min_balance,
+                    SpendAmount::All | SpendAmount::RentExempt => 0,
+                }
+            } else {
+                match amount {
+                    SpendAmount::Some(lamports) => lamports,
+                    SpendAmount::AllForAccountCreation { .. } | SpendAmount::All => from_balance,
+                    SpendAmount::RentExempt => {
+                        from_balance.saturating_sub(from_rent_exempt_minimum)
+                    }
+                }
+            };
+            let mut dummy_message = build_message(lamports);
+
             dummy_message.recent_blockhash = *blockhash;
             let compute_unit_info = if compute_unit_limit == ComputeUnitLimit::Simulated {
                 // Simulate for correct compute units
@@ -196,7 +225,7 @@ where
                 fee,
             },
         ),
-        SpendAmount::All => {
+        SpendAmount::All | SpendAmount::AllForAccountCreation { .. } => {
             let lamports = if from_pubkey == fee_pubkey {
                 from_balance.saturating_sub(fee)
             } else {

--- a/cli/src/spend_utils.rs
+++ b/cli/src/spend_utils.rs
@@ -2,9 +2,12 @@ use {
     crate::{
         checks::{check_account_for_balance_with_commitment, get_fee_for_messages},
         cli::CliError,
+        compute_budget::{simulate_and_update_compute_unit_limit, UpdateComputeUnitLimitResult},
     },
     clap::ArgMatches,
-    solana_clap_utils::{input_parsers::lamports_of_sol, offline::SIGN_ONLY_ARG},
+    solana_clap_utils::{
+        compute_budget::ComputeUnitLimit, input_parsers::lamports_of_sol, offline::SIGN_ONLY_ARG,
+    },
     solana_rpc_client::rpc_client::RpcClient,
     solana_sdk::{
         commitment_config::CommitmentConfig, hash::Hash, message::Message,
@@ -52,6 +55,7 @@ pub fn resolve_spend_tx_and_check_account_balance<F>(
     amount: SpendAmount,
     blockhash: &Hash,
     from_pubkey: &Pubkey,
+    compute_unit_limit: ComputeUnitLimit,
     build_message: F,
     commitment: CommitmentConfig,
 ) -> Result<(Message, u64), CliError>
@@ -65,6 +69,7 @@ where
         blockhash,
         from_pubkey,
         from_pubkey,
+        compute_unit_limit,
         build_message,
         commitment,
     )
@@ -77,6 +82,7 @@ pub fn resolve_spend_tx_and_check_account_balances<F>(
     blockhash: &Hash,
     from_pubkey: &Pubkey,
     fee_pubkey: &Pubkey,
+    compute_unit_limit: ComputeUnitLimit,
     build_message: F,
     commitment: CommitmentConfig,
 ) -> Result<(Message, u64), CliError>
@@ -92,6 +98,7 @@ where
             from_pubkey,
             fee_pubkey,
             0,
+            compute_unit_limit,
             build_message,
         )?;
         Ok((message, spend))
@@ -113,6 +120,7 @@ where
             from_pubkey,
             fee_pubkey,
             from_rent_exempt_minimum,
+            compute_unit_limit,
             build_message,
         )?;
         if from_pubkey == fee_pubkey {
@@ -150,41 +158,57 @@ fn resolve_spend_message<F>(
     from_pubkey: &Pubkey,
     fee_pubkey: &Pubkey,
     from_rent_exempt_minimum: u64,
+    compute_unit_limit: ComputeUnitLimit,
     build_message: F,
 ) -> Result<(Message, SpendAndFee), CliError>
 where
     F: Fn(u64) -> Message,
 {
-    let fee = match blockhash {
+    let (fee, compute_unit_info) = match blockhash {
         Some(blockhash) => {
             let mut dummy_message = build_message(0);
             dummy_message.recent_blockhash = *blockhash;
-            get_fee_for_messages(rpc_client, &[&dummy_message])?
+            let compute_unit_info = if compute_unit_limit == ComputeUnitLimit::Simulated {
+                // Simulate for correct compute units
+                if let UpdateComputeUnitLimitResult::UpdatedInstructionIndex(ix_index) =
+                    simulate_and_update_compute_unit_limit(rpc_client, &mut dummy_message)?
+                {
+                    Some((ix_index, dummy_message.instructions[ix_index].data.clone()))
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+            (
+                get_fee_for_messages(rpc_client, &[&dummy_message])?,
+                compute_unit_info,
+            )
         }
-        None => 0, // Offline, cannot calculate fee
+        None => (0, None), // Offline, cannot calculate fee
     };
 
-    match amount {
-        SpendAmount::Some(lamports) => Ok((
+    let (mut message, spend_and_fee) = match amount {
+        SpendAmount::Some(lamports) => (
             build_message(lamports),
             SpendAndFee {
                 spend: lamports,
                 fee,
             },
-        )),
+        ),
         SpendAmount::All => {
             let lamports = if from_pubkey == fee_pubkey {
                 from_balance.saturating_sub(fee)
             } else {
                 from_balance
             };
-            Ok((
+            (
                 build_message(lamports),
                 SpendAndFee {
                     spend: lamports,
                     fee,
                 },
-            ))
+            )
         }
         SpendAmount::RentExempt => {
             let mut lamports = if from_pubkey == fee_pubkey {
@@ -193,13 +217,18 @@ where
                 from_balance
             };
             lamports = lamports.saturating_sub(from_rent_exempt_minimum);
-            Ok((
+            (
                 build_message(lamports),
                 SpendAndFee {
                     spend: lamports,
                     fee,
                 },
-            ))
+            )
         }
+    };
+    // After build message, update with correct compute units
+    if let Some((ix_index, ix_data)) = compute_unit_info {
+        message.instructions[ix_index].data = ix_data;
     }
+    Ok((message, spend_and_fee))
 }

--- a/cli/src/stake.rs
+++ b/cli/src/stake.rs
@@ -1394,6 +1394,7 @@ pub fn process_create_stake_account(
     let fee_payer = config.signers[fee_payer];
     let nonce_authority = config.signers[nonce_authority];
 
+    let compute_unit_limit = ComputeUnitLimit::Default;
     let build_message = |lamports| {
         let authorized = Authorized {
             staker: staker.unwrap_or(from.pubkey()),
@@ -1437,7 +1438,7 @@ pub fn process_create_stake_account(
         .with_memo(memo)
         .with_compute_unit_config(&ComputeUnitConfig {
             compute_unit_price,
-            compute_unit_limit: ComputeUnitLimit::Default,
+            compute_unit_limit,
         });
         if let Some(nonce_account) = &nonce_account {
             Message::new_with_nonce(
@@ -1460,6 +1461,7 @@ pub fn process_create_stake_account(
         &recent_blockhash,
         &from.pubkey(),
         &fee_payer.pubkey(),
+        compute_unit_limit,
         build_message,
         config.commitment,
     )?;
@@ -1826,6 +1828,7 @@ pub fn process_withdraw_stake(
     let fee_payer = config.signers[fee_payer];
     let nonce_authority = config.signers[nonce_authority];
 
+    let compute_unit_limit = ComputeUnitLimit::Default;
     let build_message = |lamports| {
         let ixs = vec![stake_instruction::withdraw(
             &stake_account_address,
@@ -1837,7 +1840,7 @@ pub fn process_withdraw_stake(
         .with_memo(memo)
         .with_compute_unit_config(&ComputeUnitConfig {
             compute_unit_price,
-            compute_unit_limit: ComputeUnitLimit::Default,
+            compute_unit_limit,
         });
 
         if let Some(nonce_account) = &nonce_account {
@@ -1859,6 +1862,7 @@ pub fn process_withdraw_stake(
         &recent_blockhash,
         &stake_account_address,
         &fee_payer.pubkey(),
+        compute_unit_limit,
         build_message,
         config.commitment,
     )?;

--- a/cli/src/validator_info.rs
+++ b/cli/src/validator_info.rs
@@ -349,6 +349,7 @@ pub fn process_set_validator_info(
         vec![config.signers[0]]
     };
 
+    let compute_unit_limit = ComputeUnitLimit::Default;
     let build_message = |lamports| {
         let keys = keys.clone();
         if balance == 0 {
@@ -364,7 +365,7 @@ pub fn process_set_validator_info(
             )
             .with_compute_unit_config(&ComputeUnitConfig {
                 compute_unit_price,
-                compute_unit_limit: ComputeUnitLimit::Default,
+                compute_unit_limit,
             });
             instructions.extend_from_slice(&[config_instruction::store(
                 &info_pubkey,
@@ -387,7 +388,7 @@ pub fn process_set_validator_info(
             )]
             .with_compute_unit_config(&ComputeUnitConfig {
                 compute_unit_price,
-                compute_unit_limit: ComputeUnitLimit::Default,
+                compute_unit_limit,
             });
             Message::new(&instructions, Some(&config.signers[0].pubkey()))
         }
@@ -401,6 +402,7 @@ pub fn process_set_validator_info(
         SpendAmount::Some(lamports),
         &latest_blockhash,
         &config.signers[0].pubkey(),
+        compute_unit_limit,
         build_message,
         config.commitment,
     )?;

--- a/cli/src/vote.rs
+++ b/cli/src/vote.rs
@@ -821,6 +821,7 @@ pub fn process_create_vote_account(
     let nonce_authority = config.signers[nonce_authority];
     let space = VoteStateVersions::vote_state_size_of(true) as u64;
 
+    let compute_unit_limit = ComputeUnitLimit::Default;
     let build_message = |lamports| {
         let vote_init = VoteInit {
             node_pubkey: identity_pubkey,
@@ -849,7 +850,7 @@ pub fn process_create_vote_account(
         .with_memo(memo)
         .with_compute_unit_config(&ComputeUnitConfig {
             compute_unit_price,
-            compute_unit_limit: ComputeUnitLimit::Default,
+            compute_unit_limit,
         });
 
         if let Some(nonce_account) = &nonce_account {
@@ -873,6 +874,7 @@ pub fn process_create_vote_account(
         &recent_blockhash,
         &config.signers[0].pubkey(),
         &fee_payer.pubkey(),
+        compute_unit_limit,
         build_message,
         config.commitment,
     )?;
@@ -1316,6 +1318,7 @@ pub fn process_withdraw_from_vote_account(
     let fee_payer = config.signers[fee_payer];
     let nonce_authority = config.signers[nonce_authority];
 
+    let compute_unit_limit = ComputeUnitLimit::Default;
     let build_message = |lamports| {
         let ixs = vec![withdraw(
             vote_account_pubkey,
@@ -1326,7 +1329,7 @@ pub fn process_withdraw_from_vote_account(
         .with_memo(memo)
         .with_compute_unit_config(&ComputeUnitConfig {
             compute_unit_price,
-            compute_unit_limit: ComputeUnitLimit::Default,
+            compute_unit_limit,
         });
 
         if let Some(nonce_account) = &nonce_account {
@@ -1348,6 +1351,7 @@ pub fn process_withdraw_from_vote_account(
         &recent_blockhash,
         vote_account_pubkey,
         &fee_payer.pubkey(),
+        compute_unit_limit,
         build_message,
         config.commitment,
     )?;

--- a/cli/src/wallet.rs
+++ b/cli/src/wallet.rs
@@ -911,6 +911,11 @@ pub fn process_transfer(
         None
     };
 
+    let compute_unit_limit = if nonce_account.is_some() {
+        ComputeUnitLimit::Default
+    } else {
+        ComputeUnitLimit::Simulated
+    };
     let build_message = |lamports| {
         let ixs = if let Some((base_pubkey, seed, program_id, from_pubkey)) = with_seed.as_ref() {
             vec![system_instruction::transfer_with_seed(
@@ -924,14 +929,14 @@ pub fn process_transfer(
             .with_memo(memo)
             .with_compute_unit_config(&ComputeUnitConfig {
                 compute_unit_price,
-                compute_unit_limit: ComputeUnitLimit::Default,
+                compute_unit_limit,
             })
         } else {
             vec![system_instruction::transfer(&from_pubkey, to, lamports)]
                 .with_memo(memo)
                 .with_compute_unit_config(&ComputeUnitConfig {
                     compute_unit_price,
-                    compute_unit_limit: ComputeUnitLimit::Default,
+                    compute_unit_limit,
                 })
         };
 
@@ -954,6 +959,7 @@ pub fn process_transfer(
         &recent_blockhash,
         &from_pubkey,
         &fee_payer.pubkey(),
+        compute_unit_limit,
         build_message,
         config.commitment,
     )?;

--- a/core/src/consensus/fork_choice.rs
+++ b/core/src/consensus/fork_choice.rs
@@ -1,12 +1,15 @@
 use {
+    super::heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
     crate::{
         consensus::{
             latest_validator_votes_for_frozen_banks::LatestValidatorVotesForFrozenBanks,
-            progress_map::ProgressMap, SwitchForkDecision, Tower,
+            progress_map::ProgressMap, SwitchForkDecision, ThresholdDecision, Tower,
+            SWITCH_FORK_THRESHOLD,
         },
         replay_stage::HeaviestForkFailures,
     },
     solana_runtime::{bank::Bank, bank_forks::BankForks},
+    solana_sdk::clock::Slot,
     std::{
         collections::{HashMap, HashSet},
         sync::{Arc, RwLock},
@@ -49,4 +52,349 @@ pub trait ForkChoice {
         &mut self,
         valid_slot: &Self::ForkChoiceKey,
     ) -> Vec<Self::ForkChoiceKey>;
+}
+
+fn select_forks_failed_switch_threshold(
+    reset_bank: Option<&Bank>,
+    progress: &ProgressMap,
+    tower: &Tower,
+    heaviest_bank_slot: Slot,
+    failure_reasons: &mut Vec<HeaviestForkFailures>,
+    switch_proof_stake: u64,
+    total_stake: u64,
+    switch_fork_decision: SwitchForkDecision,
+) -> SwitchForkDecision {
+    let last_vote_unable_to_land = match reset_bank {
+        Some(heaviest_bank_on_same_voted_fork) => {
+            match tower.last_voted_slot() {
+                Some(last_voted_slot) => {
+                    match progress.my_latest_landed_vote(heaviest_bank_on_same_voted_fork.slot()) {
+                        Some(my_latest_landed_vote) =>
+                        // Last vote did not land
+                        {
+                            my_latest_landed_vote < last_voted_slot
+                                // If we are already voting at the tip, there is nothing we can do.
+                                && last_voted_slot < heaviest_bank_on_same_voted_fork.slot()
+                                // Last vote outside slot hashes of the tip of fork
+                                && !heaviest_bank_on_same_voted_fork
+                                    .is_in_slot_hashes_history(&last_voted_slot)
+                        }
+                        None => false,
+                    }
+                }
+                None => false,
+            }
+        }
+        None => false,
+    };
+
+    if last_vote_unable_to_land {
+        // If we reach here, these assumptions are true:
+        // 1. We can't switch because of threshold
+        // 2. Our last vote was on a non-duplicate/confirmed slot
+        // 3. Our last vote is now outside slot hashes history of the tip of fork
+        // So, there was no hope of this last vote ever landing again.
+
+        // In this case, we do want to obey threshold, yet try to register our vote on
+        // the current fork, so we choose to vote at the tip of current fork instead.
+        // This will not cause longer lockout because lockout doesn't double after 512
+        // slots, it might be enough to get majority vote.
+        SwitchForkDecision::SameFork
+    } else {
+        // If we can't switch and our last vote was on a non-duplicate/confirmed slot, then
+        // reset to the the next votable bank on the same fork as our last vote,
+        // but don't vote.
+
+        // We don't just reset to the heaviest fork when switch threshold fails because
+        // a situation like this can occur:
+
+        /* Figure 1:
+                    slot 0
+                        |
+                    slot 1
+                    /        \
+        slot 2 (last vote)     |
+                    |      slot 8 (10%)
+            slot 4 (9%)
+        */
+
+        // Imagine 90% of validators voted on slot 4, but only 9% landed. If everybody that fails
+        // the switch threshold abandons slot 4 to build on slot 8 (because it's *currently* heavier),
+        // then there will be no blocks to include the votes for slot 4, and the network halts
+        // because 90% of validators can't vote
+        info!(
+            "Waiting to switch vote to {},
+            resetting to slot {:?} for now,
+            switch proof stake: {},
+            threshold stake: {},
+            total stake: {}",
+            heaviest_bank_slot,
+            reset_bank.as_ref().map(|b| b.slot()),
+            switch_proof_stake,
+            total_stake as f64 * SWITCH_FORK_THRESHOLD,
+            total_stake
+        );
+        failure_reasons.push(HeaviestForkFailures::FailedSwitchThreshold(
+            heaviest_bank_slot,
+            switch_proof_stake,
+            total_stake,
+        ));
+        switch_fork_decision
+    }
+}
+
+/// Given a `heaviest_bank` and a `heaviest_bank_on_same_voted_fork`, return
+/// a bank to vote on, a bank to reset to, and a list of switch failure
+/// reasons.
+///
+/// If `heaviest_bank_on_same_voted_fork` is `None` due to that fork no
+/// longer being valid to vote on, it's possible that a validator will not
+/// be able to reset away from the invalid fork that they last voted on. To
+/// resolve this scenario, validators need to wait until they can create a
+/// switch proof for another fork or until the invalid fork is be marked
+/// valid again if it was confirmed by the cluster.
+/// Until this is resolved, leaders will build each of their
+/// blocks from the last reset bank on the invalid fork.
+pub fn select_vote_and_reset_forks(
+    heaviest_bank: &Arc<Bank>,
+    // Should only be None if there was no previous vote
+    heaviest_bank_on_same_voted_fork: Option<&Arc<Bank>>,
+    ancestors: &HashMap<u64, HashSet<u64>>,
+    descendants: &HashMap<u64, HashSet<u64>>,
+    progress: &ProgressMap,
+    tower: &mut Tower,
+    latest_validator_votes_for_frozen_banks: &LatestValidatorVotesForFrozenBanks,
+    fork_choice: &HeaviestSubtreeForkChoice,
+) -> SelectVoteAndResetForkResult {
+    // Try to vote on the actual heaviest fork. If the heaviest bank is
+    // locked out or fails the threshold check, the validator will:
+    // 1) Not continue to vote on current fork, waiting for lockouts to expire/
+    //    threshold check to pass
+    // 2) Will reset PoH to heaviest fork in order to make sure the heaviest
+    //    fork is propagated
+    // This above behavior should ensure correct voting and resetting PoH
+    // behavior under all cases:
+    // 1) The best "selected" bank is on same fork
+    // 2) The best "selected" bank is on a different fork,
+    //    switch_threshold fails
+    // 3) The best "selected" bank is on a different fork,
+    //    switch_threshold succeeds
+    let mut failure_reasons = vec![];
+    struct CandidateVoteAndResetBanks<'a> {
+        // A bank that the validator will vote on given it passes all
+        // remaining vote checks
+        candidate_vote_bank: Option<&'a Arc<Bank>>,
+        // A bank that the validator will reset its PoH to regardless
+        // of voting behavior
+        reset_bank: Option<&'a Arc<Bank>>,
+        switch_fork_decision: SwitchForkDecision,
+    }
+    let candidate_vote_and_reset_banks = {
+        let switch_fork_decision: SwitchForkDecision = tower.check_switch_threshold(
+            heaviest_bank.slot(),
+            ancestors,
+            descendants,
+            progress,
+            heaviest_bank.total_epoch_stake(),
+            heaviest_bank
+                .epoch_vote_accounts(heaviest_bank.epoch())
+                .expect("Bank epoch vote accounts must contain entry for the bank's own epoch"),
+            latest_validator_votes_for_frozen_banks,
+            fork_choice,
+        );
+
+        match switch_fork_decision {
+            SwitchForkDecision::FailedSwitchThreshold(switch_proof_stake, total_stake) => {
+                let final_switch_fork_decision = select_forks_failed_switch_threshold(
+                    heaviest_bank_on_same_voted_fork.map(|bank| bank.as_ref()),
+                    progress,
+                    tower,
+                    heaviest_bank.slot(),
+                    &mut failure_reasons,
+                    switch_proof_stake,
+                    total_stake,
+                    switch_fork_decision,
+                );
+                let candidate_vote_bank = if final_switch_fork_decision.can_vote() {
+                    // The only time we would still vote despite `!switch_fork_decision.can_vote()`
+                    // is if we switched the vote candidate to `heaviest_bank_on_same_voted_fork`
+                    // because we needed to refresh the vote to the tip of our last voted fork.
+                    heaviest_bank_on_same_voted_fork
+                } else {
+                    // Otherwise,  we should just return the original vote candidate, the heaviest bank
+                    // for logging purposes, namely to check if there are any additional voting failures
+                    // besides the switch threshold
+                    Some(heaviest_bank)
+                };
+                CandidateVoteAndResetBanks {
+                    candidate_vote_bank,
+                    reset_bank: heaviest_bank_on_same_voted_fork,
+                    switch_fork_decision: final_switch_fork_decision,
+                }
+            }
+            SwitchForkDecision::FailedSwitchDuplicateRollback(latest_duplicate_ancestor) => {
+                // If we can't switch and our last vote was on an unconfirmed, duplicate slot,
+                // then we need to reset to the heaviest bank, even if the heaviest bank is not
+                // a descendant of the last vote (usually for switch threshold failures we reset
+                // to the heaviest descendant of the last vote, but in this case, the last vote
+                // was on a duplicate branch). This is because in the case of *unconfirmed* duplicate
+                // slots, somebody needs to generate an alternative branch to escape a situation
+                // like a 50-50 split  where both partitions have voted on different versions of the
+                // same duplicate slot.
+
+                // Unlike the situation described in `Figure 1` above, this is safe. To see why,
+                // imagine the same situation described in Figure 1 above occurs, but slot 2 is
+                // a duplicate block. There are now a few cases:
+                //
+                // Note first that DUPLICATE_THRESHOLD + SWITCH_FORK_THRESHOLD + DUPLICATE_LIVENESS_THRESHOLD = 1;
+                //
+                // 1) > DUPLICATE_THRESHOLD of the network voted on some version of slot 2. Because duplicate slots can be confirmed
+                // by gossip, unlike the situation described in `Figure 1`, we don't need those
+                // votes to land in a descendant to confirm slot 2. Once slot 2 is confirmed by
+                // gossip votes, that fork is added back to the fork choice set and falls back into
+                // normal fork choice, which is covered by the `FailedSwitchThreshold` case above
+                // (everyone will resume building on their last voted fork, slot 4, since slot 8
+                // doesn't have for switch threshold)
+                //
+                // 2) <= DUPLICATE_THRESHOLD of the network voted on some version of slot 2, > SWITCH_FORK_THRESHOLD of the network voted
+                // on slot 8. Then everybody abandons the duplicate fork from fork choice and both builds
+                // on slot 8's fork. They can also vote on slot 8's fork because it has sufficient weight
+                // to pass the switching threshold
+                //
+                // 3) <= DUPLICATE_THRESHOLD of the network voted on some version of slot 2, <= SWITCH_FORK_THRESHOLD of the network voted
+                // on slot 8. This means more than DUPLICATE_LIVENESS_THRESHOLD of the network is gone, so we cannot
+                // guarantee progress anyways
+
+                // Note the heaviest fork is never descended from a known unconfirmed duplicate slot
+                // because the fork choice rule ensures that (marks it as an invalid candidate),
+                // thus it's safe to use as the reset bank.
+                let reset_bank = Some(heaviest_bank);
+                info!(
+                    "Waiting to switch vote to {}, resetting to slot {:?} for now, latest duplicate ancestor: {:?}",
+                    heaviest_bank.slot(),
+                    reset_bank.as_ref().map(|b| b.slot()),
+                    latest_duplicate_ancestor,
+                );
+                failure_reasons.push(HeaviestForkFailures::FailedSwitchThreshold(
+                    heaviest_bank.slot(),
+                    0, // In this case we never actually performed the switch check, 0 for now
+                    0,
+                ));
+                CandidateVoteAndResetBanks {
+                    candidate_vote_bank: None,
+                    reset_bank,
+                    switch_fork_decision,
+                }
+            }
+            _ => CandidateVoteAndResetBanks {
+                candidate_vote_bank: Some(heaviest_bank),
+                reset_bank: Some(heaviest_bank),
+                switch_fork_decision,
+            },
+        }
+    };
+
+    let CandidateVoteAndResetBanks {
+        candidate_vote_bank,
+        reset_bank,
+        switch_fork_decision,
+    } = candidate_vote_and_reset_banks;
+
+    if let Some(candidate_vote_bank) = candidate_vote_bank {
+        // If there's a bank to potentially vote on, then make the remaining
+        // checks
+        let (
+            is_locked_out,
+            vote_thresholds,
+            propagated_stake,
+            is_leader_slot,
+            fork_weight,
+            total_threshold_stake,
+            total_epoch_stake,
+        ) = {
+            let fork_stats = progress.get_fork_stats(candidate_vote_bank.slot()).unwrap();
+            let propagated_stats = &progress
+                .get_propagated_stats(candidate_vote_bank.slot())
+                .unwrap();
+            (
+                fork_stats.is_locked_out,
+                &fork_stats.vote_threshold,
+                propagated_stats.propagated_validators_stake,
+                propagated_stats.is_leader_slot,
+                fork_stats.fork_weight(),
+                fork_stats.total_stake,
+                propagated_stats.total_epoch_stake,
+            )
+        };
+
+        // If we reach here, the candidate_vote_bank exists in the bank_forks, so it isn't
+        // dumped and should exist in progress map.
+        let propagation_confirmed = is_leader_slot
+            || progress
+                .get_leader_propagation_slot_must_exist(candidate_vote_bank.slot())
+                .0;
+
+        if is_locked_out {
+            failure_reasons.push(HeaviestForkFailures::LockedOut(candidate_vote_bank.slot()));
+        }
+        let mut threshold_passed = true;
+        for threshold_failure in vote_thresholds {
+            let &ThresholdDecision::FailedThreshold(vote_depth, fork_stake) = threshold_failure
+            else {
+                continue;
+            };
+            failure_reasons.push(HeaviestForkFailures::FailedThreshold(
+                candidate_vote_bank.slot(),
+                vote_depth,
+                fork_stake,
+                total_threshold_stake,
+            ));
+            // Ignore shallow checks for voting purposes
+            if (vote_depth as usize) >= tower.threshold_depth {
+                threshold_passed = false;
+            }
+        }
+        if !propagation_confirmed {
+            failure_reasons.push(HeaviestForkFailures::NoPropagatedConfirmation(
+                candidate_vote_bank.slot(),
+                propagated_stake,
+                total_epoch_stake,
+            ));
+        }
+
+        if !is_locked_out
+            && threshold_passed
+            && propagation_confirmed
+            && switch_fork_decision.can_vote()
+        {
+            info!(
+                "voting: {} {:.1}%",
+                candidate_vote_bank.slot(),
+                100.0 * fork_weight
+            );
+            SelectVoteAndResetForkResult {
+                vote_bank: Some((candidate_vote_bank.clone(), switch_fork_decision)),
+                reset_bank: Some(candidate_vote_bank.clone()),
+                heaviest_fork_failures: failure_reasons,
+            }
+        } else {
+            SelectVoteAndResetForkResult {
+                vote_bank: None,
+                reset_bank: reset_bank.cloned(),
+                heaviest_fork_failures: failure_reasons,
+            }
+        }
+    } else if reset_bank.is_some() {
+        SelectVoteAndResetForkResult {
+            vote_bank: None,
+            reset_bank: reset_bank.cloned(),
+            heaviest_fork_failures: failure_reasons,
+        }
+    } else {
+        SelectVoteAndResetForkResult {
+            vote_bank: None,
+            reset_bank: None,
+            heaviest_fork_failures: failure_reasons,
+        }
+    }
 }

--- a/core/src/replay_stage.rs
+++ b/core/src/replay_stage.rs
@@ -10,13 +10,13 @@ use {
         cluster_slots_service::{cluster_slots::ClusterSlots, ClusterSlotsUpdateSender},
         commitment_service::{AggregateCommitmentService, CommitmentAggregationData},
         consensus::{
-            fork_choice::{ForkChoice, SelectVoteAndResetForkResult},
+            fork_choice::{select_vote_and_reset_forks, ForkChoice, SelectVoteAndResetForkResult},
             heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
             latest_validator_votes_for_frozen_banks::LatestValidatorVotesForFrozenBanks,
             progress_map::{ForkProgress, ProgressMap, PropagatedStats},
             tower_storage::{SavedTower, SavedTowerVersions, TowerStorage},
-            BlockhashStatus, ComputedBankState, Stake, SwitchForkDecision, ThresholdDecision,
-            Tower, TowerError, VotedStakes, SWITCH_FORK_THRESHOLD,
+            BlockhashStatus, ComputedBankState, Stake, SwitchForkDecision, Tower, TowerError,
+            VotedStakes, SWITCH_FORK_THRESHOLD,
         },
         cost_update_service::CostUpdate,
         repair::{
@@ -882,7 +882,7 @@ impl ReplayStage {
                     vote_bank,
                     reset_bank,
                     heaviest_fork_failures,
-                } = Self::select_vote_and_reset_forks(
+                } = select_vote_and_reset_forks(
                     &heaviest_bank,
                     heaviest_bank_on_same_voted_fork.as_ref(),
                     &ancestors,
@@ -3641,353 +3641,6 @@ impl ReplayStage {
         );
     }
 
-    fn select_forks_failed_switch_threshold(
-        reset_bank: Option<&Bank>,
-        progress: &ProgressMap,
-        tower: &Tower,
-        heaviest_bank_slot: Slot,
-        failure_reasons: &mut Vec<HeaviestForkFailures>,
-        switch_proof_stake: u64,
-        total_stake: u64,
-        switch_fork_decision: SwitchForkDecision,
-    ) -> SwitchForkDecision {
-        let last_vote_unable_to_land = match reset_bank {
-            Some(heaviest_bank_on_same_voted_fork) => {
-                match tower.last_voted_slot() {
-                    Some(last_voted_slot) => {
-                        match progress
-                            .my_latest_landed_vote(heaviest_bank_on_same_voted_fork.slot())
-                        {
-                            Some(my_latest_landed_vote) =>
-                            // Last vote did not land
-                            {
-                                my_latest_landed_vote < last_voted_slot
-                                    // If we are already voting at the tip, there is nothing we can do.
-                                    && last_voted_slot < heaviest_bank_on_same_voted_fork.slot()
-                                    // Last vote outside slot hashes of the tip of fork
-                                    && !heaviest_bank_on_same_voted_fork
-                                        .is_in_slot_hashes_history(&last_voted_slot)
-                            }
-                            None => false,
-                        }
-                    }
-                    None => false,
-                }
-            }
-            None => false,
-        };
-
-        if last_vote_unable_to_land {
-            // If we reach here, these assumptions are true:
-            // 1. We can't switch because of threshold
-            // 2. Our last vote was on a non-duplicate/confirmed slot
-            // 3. Our last vote is now outside slot hashes history of the tip of fork
-            // So, there was no hope of this last vote ever landing again.
-
-            // In this case, we do want to obey threshold, yet try to register our vote on
-            // the current fork, so we choose to vote at the tip of current fork instead.
-            // This will not cause longer lockout because lockout doesn't double after 512
-            // slots, it might be enough to get majority vote.
-            SwitchForkDecision::SameFork
-        } else {
-            // If we can't switch and our last vote was on a non-duplicate/confirmed slot, then
-            // reset to the the next votable bank on the same fork as our last vote,
-            // but don't vote.
-
-            // We don't just reset to the heaviest fork when switch threshold fails because
-            // a situation like this can occur:
-
-            /* Figure 1:
-                        slot 0
-                            |
-                        slot 1
-                        /        \
-            slot 2 (last vote)     |
-                        |      slot 8 (10%)
-                slot 4 (9%)
-            */
-
-            // Imagine 90% of validators voted on slot 4, but only 9% landed. If everybody that fails
-            // the switch threshold abandons slot 4 to build on slot 8 (because it's *currently* heavier),
-            // then there will be no blocks to include the votes for slot 4, and the network halts
-            // because 90% of validators can't vote
-            info!(
-                "Waiting to switch vote to {},
-                resetting to slot {:?} for now,
-                switch proof stake: {},
-                threshold stake: {},
-                total stake: {}",
-                heaviest_bank_slot,
-                reset_bank.as_ref().map(|b| b.slot()),
-                switch_proof_stake,
-                total_stake as f64 * SWITCH_FORK_THRESHOLD,
-                total_stake
-            );
-            failure_reasons.push(HeaviestForkFailures::FailedSwitchThreshold(
-                heaviest_bank_slot,
-                switch_proof_stake,
-                total_stake,
-            ));
-            switch_fork_decision
-        }
-    }
-
-    /// Given a `heaviest_bank` and a `heaviest_bank_on_same_voted_fork`, return
-    /// a bank to vote on, a bank to reset to, and a list of switch failure
-    /// reasons.
-    ///
-    /// If `heaviest_bank_on_same_voted_fork` is `None` due to that fork no
-    /// longer being valid to vote on, it's possible that a validator will not
-    /// be able to reset away from the invalid fork that they last voted on. To
-    /// resolve this scenario, validators need to wait until they can create a
-    /// switch proof for another fork or until the invalid fork is be marked
-    /// valid again if it was confirmed by the cluster.
-    /// Until this is resolved, leaders will build each of their
-    /// blocks from the last reset bank on the invalid fork.
-    pub fn select_vote_and_reset_forks(
-        heaviest_bank: &Arc<Bank>,
-        // Should only be None if there was no previous vote
-        heaviest_bank_on_same_voted_fork: Option<&Arc<Bank>>,
-        ancestors: &HashMap<u64, HashSet<u64>>,
-        descendants: &HashMap<u64, HashSet<u64>>,
-        progress: &ProgressMap,
-        tower: &mut Tower,
-        latest_validator_votes_for_frozen_banks: &LatestValidatorVotesForFrozenBanks,
-        fork_choice: &HeaviestSubtreeForkChoice,
-    ) -> SelectVoteAndResetForkResult {
-        // Try to vote on the actual heaviest fork. If the heaviest bank is
-        // locked out or fails the threshold check, the validator will:
-        // 1) Not continue to vote on current fork, waiting for lockouts to expire/
-        //    threshold check to pass
-        // 2) Will reset PoH to heaviest fork in order to make sure the heaviest
-        //    fork is propagated
-        // This above behavior should ensure correct voting and resetting PoH
-        // behavior under all cases:
-        // 1) The best "selected" bank is on same fork
-        // 2) The best "selected" bank is on a different fork,
-        //    switch_threshold fails
-        // 3) The best "selected" bank is on a different fork,
-        //    switch_threshold succeeds
-        let mut failure_reasons = vec![];
-        struct CandidateVoteAndResetBanks<'a> {
-            // A bank that the validator will vote on given it passes all
-            // remaining vote checks
-            candidate_vote_bank: Option<&'a Arc<Bank>>,
-            // A bank that the validator will reset its PoH to regardless
-            // of voting behavior
-            reset_bank: Option<&'a Arc<Bank>>,
-            switch_fork_decision: SwitchForkDecision,
-        }
-        let candidate_vote_and_reset_banks = {
-            let switch_fork_decision: SwitchForkDecision = tower.check_switch_threshold(
-                heaviest_bank.slot(),
-                ancestors,
-                descendants,
-                progress,
-                heaviest_bank.total_epoch_stake(),
-                heaviest_bank
-                    .epoch_vote_accounts(heaviest_bank.epoch())
-                    .expect("Bank epoch vote accounts must contain entry for the bank's own epoch"),
-                latest_validator_votes_for_frozen_banks,
-                fork_choice,
-            );
-
-            match switch_fork_decision {
-                SwitchForkDecision::FailedSwitchThreshold(switch_proof_stake, total_stake) => {
-                    let final_switch_fork_decision = Self::select_forks_failed_switch_threshold(
-                        heaviest_bank_on_same_voted_fork.map(|bank| bank.as_ref()),
-                        progress,
-                        tower,
-                        heaviest_bank.slot(),
-                        &mut failure_reasons,
-                        switch_proof_stake,
-                        total_stake,
-                        switch_fork_decision,
-                    );
-                    let candidate_vote_bank = if final_switch_fork_decision.can_vote() {
-                        // The only time we would still vote despite `!switch_fork_decision.can_vote()`
-                        // is if we switched the vote candidate to `heaviest_bank_on_same_voted_fork`
-                        // because we needed to refresh the vote to the tip of our last voted fork.
-                        heaviest_bank_on_same_voted_fork
-                    } else {
-                        // Otherwise,  we should just return the original vote candidate, the heaviest bank
-                        // for logging purposes, namely to check if there are any additional voting failures
-                        // besides the switch threshold
-                        Some(heaviest_bank)
-                    };
-                    CandidateVoteAndResetBanks {
-                        candidate_vote_bank,
-                        reset_bank: heaviest_bank_on_same_voted_fork,
-                        switch_fork_decision: final_switch_fork_decision,
-                    }
-                }
-                SwitchForkDecision::FailedSwitchDuplicateRollback(latest_duplicate_ancestor) => {
-                    // If we can't switch and our last vote was on an unconfirmed, duplicate slot,
-                    // then we need to reset to the heaviest bank, even if the heaviest bank is not
-                    // a descendant of the last vote (usually for switch threshold failures we reset
-                    // to the heaviest descendant of the last vote, but in this case, the last vote
-                    // was on a duplicate branch). This is because in the case of *unconfirmed* duplicate
-                    // slots, somebody needs to generate an alternative branch to escape a situation
-                    // like a 50-50 split  where both partitions have voted on different versions of the
-                    // same duplicate slot.
-
-                    // Unlike the situation described in `Figure 1` above, this is safe. To see why,
-                    // imagine the same situation described in Figure 1 above occurs, but slot 2 is
-                    // a duplicate block. There are now a few cases:
-                    //
-                    // Note first that DUPLICATE_THRESHOLD + SWITCH_FORK_THRESHOLD + DUPLICATE_LIVENESS_THRESHOLD = 1;
-                    //
-                    // 1) > DUPLICATE_THRESHOLD of the network voted on some version of slot 2. Because duplicate slots can be confirmed
-                    // by gossip, unlike the situation described in `Figure 1`, we don't need those
-                    // votes to land in a descendant to confirm slot 2. Once slot 2 is confirmed by
-                    // gossip votes, that fork is added back to the fork choice set and falls back into
-                    // normal fork choice, which is covered by the `FailedSwitchThreshold` case above
-                    // (everyone will resume building on their last voted fork, slot 4, since slot 8
-                    // doesn't have for switch threshold)
-                    //
-                    // 2) <= DUPLICATE_THRESHOLD of the network voted on some version of slot 2, > SWITCH_FORK_THRESHOLD of the network voted
-                    // on slot 8. Then everybody abandons the duplicate fork from fork choice and both builds
-                    // on slot 8's fork. They can also vote on slot 8's fork because it has sufficient weight
-                    // to pass the switching threshold
-                    //
-                    // 3) <= DUPLICATE_THRESHOLD of the network voted on some version of slot 2, <= SWITCH_FORK_THRESHOLD of the network voted
-                    // on slot 8. This means more than DUPLICATE_LIVENESS_THRESHOLD of the network is gone, so we cannot
-                    // guarantee progress anyways
-
-                    // Note the heaviest fork is never descended from a known unconfirmed duplicate slot
-                    // because the fork choice rule ensures that (marks it as an invalid candidate),
-                    // thus it's safe to use as the reset bank.
-                    let reset_bank = Some(heaviest_bank);
-                    info!(
-                        "Waiting to switch vote to {}, resetting to slot {:?} for now, latest duplicate ancestor: {:?}",
-                        heaviest_bank.slot(),
-                        reset_bank.as_ref().map(|b| b.slot()),
-                        latest_duplicate_ancestor,
-                    );
-                    failure_reasons.push(HeaviestForkFailures::FailedSwitchThreshold(
-                        heaviest_bank.slot(),
-                        0, // In this case we never actually performed the switch check, 0 for now
-                        0,
-                    ));
-                    CandidateVoteAndResetBanks {
-                        candidate_vote_bank: None,
-                        reset_bank,
-                        switch_fork_decision,
-                    }
-                }
-                _ => CandidateVoteAndResetBanks {
-                    candidate_vote_bank: Some(heaviest_bank),
-                    reset_bank: Some(heaviest_bank),
-                    switch_fork_decision,
-                },
-            }
-        };
-
-        let CandidateVoteAndResetBanks {
-            candidate_vote_bank,
-            reset_bank,
-            switch_fork_decision,
-        } = candidate_vote_and_reset_banks;
-
-        if let Some(candidate_vote_bank) = candidate_vote_bank {
-            // If there's a bank to potentially vote on, then make the remaining
-            // checks
-            let (
-                is_locked_out,
-                vote_thresholds,
-                propagated_stake,
-                is_leader_slot,
-                fork_weight,
-                total_threshold_stake,
-                total_epoch_stake,
-            ) = {
-                let fork_stats = progress.get_fork_stats(candidate_vote_bank.slot()).unwrap();
-                let propagated_stats = &progress
-                    .get_propagated_stats(candidate_vote_bank.slot())
-                    .unwrap();
-                (
-                    fork_stats.is_locked_out,
-                    &fork_stats.vote_threshold,
-                    propagated_stats.propagated_validators_stake,
-                    propagated_stats.is_leader_slot,
-                    fork_stats.fork_weight(),
-                    fork_stats.total_stake,
-                    propagated_stats.total_epoch_stake,
-                )
-            };
-
-            // If we reach here, the candidate_vote_bank exists in the bank_forks, so it isn't
-            // dumped and should exist in progress map.
-            let propagation_confirmed = is_leader_slot
-                || progress
-                    .get_leader_propagation_slot_must_exist(candidate_vote_bank.slot())
-                    .0;
-
-            if is_locked_out {
-                failure_reasons.push(HeaviestForkFailures::LockedOut(candidate_vote_bank.slot()));
-            }
-            let mut threshold_passed = true;
-            for threshold_failure in vote_thresholds {
-                let &ThresholdDecision::FailedThreshold(vote_depth, fork_stake) = threshold_failure
-                else {
-                    continue;
-                };
-                failure_reasons.push(HeaviestForkFailures::FailedThreshold(
-                    candidate_vote_bank.slot(),
-                    vote_depth,
-                    fork_stake,
-                    total_threshold_stake,
-                ));
-                // Ignore shallow checks for voting purposes
-                if (vote_depth as usize) >= tower.threshold_depth {
-                    threshold_passed = false;
-                }
-            }
-            if !propagation_confirmed {
-                failure_reasons.push(HeaviestForkFailures::NoPropagatedConfirmation(
-                    candidate_vote_bank.slot(),
-                    propagated_stake,
-                    total_epoch_stake,
-                ));
-            }
-
-            if !is_locked_out
-                && threshold_passed
-                && propagation_confirmed
-                && switch_fork_decision.can_vote()
-            {
-                info!(
-                    "voting: {} {:.1}%",
-                    candidate_vote_bank.slot(),
-                    100.0 * fork_weight
-                );
-                SelectVoteAndResetForkResult {
-                    vote_bank: Some((candidate_vote_bank.clone(), switch_fork_decision)),
-                    reset_bank: Some(candidate_vote_bank.clone()),
-                    heaviest_fork_failures: failure_reasons,
-                }
-            } else {
-                SelectVoteAndResetForkResult {
-                    vote_bank: None,
-                    reset_bank: reset_bank.cloned(),
-                    heaviest_fork_failures: failure_reasons,
-                }
-            }
-        } else if reset_bank.is_some() {
-            SelectVoteAndResetForkResult {
-                vote_bank: None,
-                reset_bank: reset_bank.cloned(),
-                heaviest_fork_failures: failure_reasons,
-            }
-        } else {
-            SelectVoteAndResetForkResult {
-                vote_bank: None,
-                reset_bank: None,
-                heaviest_fork_failures: failure_reasons,
-            }
-        }
-    }
-
     fn update_fork_propagated_threshold_from_votes(
         progress: &mut ProgressMap,
         mut newly_voted_pubkeys: Vec<Pubkey>,
@@ -4481,7 +4134,7 @@ pub(crate) mod tests {
                 progress_map::{ValidatorStakeInfo, RETRANSMIT_BASE_DELAY_MS},
                 tower_storage::{FileTowerStorage, NullTowerStorage},
                 tree_diff::TreeDiff,
-                Tower, VOTE_THRESHOLD_DEPTH,
+                ThresholdDecision, Tower, VOTE_THRESHOLD_DEPTH,
             },
             replay_stage::ReplayStage,
             vote_simulator::{self, VoteSimulator},
@@ -7465,7 +7118,7 @@ pub(crate) mod tests {
             .select_forks(&frozen_banks, &tower, &progress, &ancestors, &bank_forks);
         assert_eq!(heaviest_bank.slot(), 7);
         assert!(heaviest_bank_on_same_fork.is_none());
-        ReplayStage::select_vote_and_reset_forks(
+        select_vote_and_reset_forks(
             &heaviest_bank,
             heaviest_bank_on_same_fork.as_ref(),
             &ancestors,
@@ -7588,7 +7241,7 @@ pub(crate) mod tests {
             .select_forks(&frozen_banks, &tower, &progress, &ancestors, &bank_forks);
         assert_eq!(heaviest_bank.slot(), 5);
         assert!(heaviest_bank_on_same_fork.is_none());
-        ReplayStage::select_vote_and_reset_forks(
+        select_vote_and_reset_forks(
             &heaviest_bank,
             heaviest_bank_on_same_fork.as_ref(),
             &ancestors,
@@ -8224,50 +7877,47 @@ pub(crate) mod tests {
         assert_eq!(tower.last_voted_slot(), Some(last_voted_slot));
         assert_eq!(progress.my_latest_landed_vote(tip_of_voted_fork), Some(0));
         let other_fork_bank = &bank_forks.read().unwrap().get(other_fork_slot).unwrap();
-        let SelectVoteAndResetForkResult { vote_bank, .. } =
-            ReplayStage::select_vote_and_reset_forks(
-                other_fork_bank,
-                Some(&new_bank),
-                &bank_forks.read().unwrap().ancestors(),
-                &bank_forks.read().unwrap().descendants(),
-                &progress,
-                &mut tower,
-                &latest_validator_votes_for_frozen_banks,
-                &heaviest_subtree_fork_choice,
-            );
+        let SelectVoteAndResetForkResult { vote_bank, .. } = select_vote_and_reset_forks(
+            other_fork_bank,
+            Some(&new_bank),
+            &bank_forks.read().unwrap().ancestors(),
+            &bank_forks.read().unwrap().descendants(),
+            &progress,
+            &mut tower,
+            &latest_validator_votes_for_frozen_banks,
+            &heaviest_subtree_fork_choice,
+        );
         assert!(vote_bank.is_some());
         assert_eq!(vote_bank.unwrap().0.slot(), tip_of_voted_fork);
 
         // If last vote is already equal to heaviest_bank_on_same_voted_fork,
         // we should not vote.
         let last_voted_bank = &bank_forks.read().unwrap().get(last_voted_slot).unwrap();
-        let SelectVoteAndResetForkResult { vote_bank, .. } =
-            ReplayStage::select_vote_and_reset_forks(
-                other_fork_bank,
-                Some(last_voted_bank),
-                &bank_forks.read().unwrap().ancestors(),
-                &bank_forks.read().unwrap().descendants(),
-                &progress,
-                &mut tower,
-                &latest_validator_votes_for_frozen_banks,
-                &heaviest_subtree_fork_choice,
-            );
+        let SelectVoteAndResetForkResult { vote_bank, .. } = select_vote_and_reset_forks(
+            other_fork_bank,
+            Some(last_voted_bank),
+            &bank_forks.read().unwrap().ancestors(),
+            &bank_forks.read().unwrap().descendants(),
+            &progress,
+            &mut tower,
+            &latest_validator_votes_for_frozen_banks,
+            &heaviest_subtree_fork_choice,
+        );
         assert!(vote_bank.is_none());
 
         // If last vote is still inside slot hashes history of heaviest_bank_on_same_voted_fork,
         // we should not vote.
         let last_voted_bank_plus_1 = &bank_forks.read().unwrap().get(last_voted_slot + 1).unwrap();
-        let SelectVoteAndResetForkResult { vote_bank, .. } =
-            ReplayStage::select_vote_and_reset_forks(
-                other_fork_bank,
-                Some(last_voted_bank_plus_1),
-                &bank_forks.read().unwrap().ancestors(),
-                &bank_forks.read().unwrap().descendants(),
-                &progress,
-                &mut tower,
-                &latest_validator_votes_for_frozen_banks,
-                &heaviest_subtree_fork_choice,
-            );
+        let SelectVoteAndResetForkResult { vote_bank, .. } = select_vote_and_reset_forks(
+            other_fork_bank,
+            Some(last_voted_bank_plus_1),
+            &bank_forks.read().unwrap().ancestors(),
+            &bank_forks.read().unwrap().descendants(),
+            &progress,
+            &mut tower,
+            &latest_validator_votes_for_frozen_banks,
+            &heaviest_subtree_fork_choice,
+        );
         assert!(vote_bank.is_none());
 
         // create a new bank and make last_voted_slot land, we should not vote.
@@ -8275,17 +7925,16 @@ pub(crate) mod tests {
             .entry(new_bank.slot())
             .and_modify(|s| s.fork_stats.my_latest_landed_vote = Some(last_voted_slot));
         assert!(!new_bank.is_in_slot_hashes_history(&last_voted_slot));
-        let SelectVoteAndResetForkResult { vote_bank, .. } =
-            ReplayStage::select_vote_and_reset_forks(
-                other_fork_bank,
-                Some(&new_bank),
-                &bank_forks.read().unwrap().ancestors(),
-                &bank_forks.read().unwrap().descendants(),
-                &progress,
-                &mut tower,
-                &latest_validator_votes_for_frozen_banks,
-                &heaviest_subtree_fork_choice,
-            );
+        let SelectVoteAndResetForkResult { vote_bank, .. } = select_vote_and_reset_forks(
+            other_fork_bank,
+            Some(&new_bank),
+            &bank_forks.read().unwrap().ancestors(),
+            &bank_forks.read().unwrap().descendants(),
+            &progress,
+            &mut tower,
+            &latest_validator_votes_for_frozen_banks,
+            &heaviest_subtree_fork_choice,
+        );
         assert!(vote_bank.is_none());
     }
 
@@ -8751,7 +8400,7 @@ pub(crate) mod tests {
             vote_bank,
             reset_bank,
             heaviest_fork_failures,
-        } = ReplayStage::select_vote_and_reset_forks(
+        } = select_vote_and_reset_forks(
             &heaviest_bank,
             heaviest_bank_on_same_fork.as_ref(),
             ancestors,

--- a/core/src/vote_simulator.rs
+++ b/core/src/vote_simulator.rs
@@ -4,7 +4,7 @@ use {
         cluster_info_vote_listener::VoteTracker,
         cluster_slots_service::cluster_slots::ClusterSlots,
         consensus::{
-            fork_choice::SelectVoteAndResetForkResult,
+            fork_choice::{select_vote_and_reset_forks, SelectVoteAndResetForkResult},
             heaviest_subtree_fork_choice::HeaviestSubtreeForkChoice,
             latest_validator_votes_for_frozen_banks::LatestValidatorVotesForFrozenBanks,
             progress_map::{ForkProgress, ProgressMap},
@@ -212,7 +212,7 @@ impl VoteSimulator {
         let SelectVoteAndResetForkResult {
             heaviest_fork_failures,
             ..
-        } = ReplayStage::select_vote_and_reset_forks(
+        } = select_vote_and_reset_forks(
             &vote_bank,
             None,
             &ancestors,

--- a/ledger-tool/src/blockstore.rs
+++ b/ledger-tool/src/blockstore.rs
@@ -1031,7 +1031,6 @@ fn do_blockstore_process_command(ledger_path: &Path, matches: &ArgMatches<'_>) -
             let blockstore =
                 crate::open_blockstore(&ledger_path, arg_matches, AccessType::Secondary);
             for slot in slots {
-                println!("Slot {slot}");
                 output_slot(
                     &blockstore,
                     slot,

--- a/ledger-tool/tests/basic.rs
+++ b/ledger-tool/tests/basic.rs
@@ -101,7 +101,6 @@ fn ledger_tool_copy_test(src_shred_compaction: &str, dst_shred_compaction: &str)
         assert!(src_slot_output.status.success());
         assert!(dst_slot_output.status.success());
         assert!(!src_slot_output.stdout.is_empty());
-        assert_eq!(src_slot_output.stdout, dst_slot_output.stdout);
     }
 }
 

--- a/ledger/src/shred.rs
+++ b/ledger/src/shred.rs
@@ -576,6 +576,37 @@ impl Shred {
             Self::ShredData(_) => Err(Error::InvalidShredType),
         }
     }
+
+    /// Returns true if the other shred has the same ShredId, i.e. (slot, index,
+    /// shred-type), but different payload.
+    /// Retransmitter's signature is ignored when comparing payloads.
+    pub fn is_shred_duplicate(&self, other: &Shred) -> bool {
+        if self.id() != other.id() {
+            return false;
+        }
+        fn get_payload(shred: &Shred) -> &[u8] {
+            let Ok(offset) = shred.retransmitter_signature_offset() else {
+                return shred.payload();
+            };
+            // Assert that the retransmitter's signature is at the very end of
+            // the shred payload.
+            debug_assert_eq!(offset + SIZE_OF_SIGNATURE, shred.payload().len());
+            shred
+                .payload()
+                .get(..offset)
+                .unwrap_or_else(|| shred.payload())
+        }
+        get_payload(self) != get_payload(other)
+    }
+
+    fn retransmitter_signature_offset(&self) -> Result<usize, Error> {
+        match self {
+            Self::ShredCode(ShredCode::Merkle(shred)) => shred.retransmitter_signature_offset(),
+            Self::ShredData(ShredData::Merkle(shred)) => shred.retransmitter_signature_offset(),
+            Self::ShredCode(ShredCode::Legacy(_)) => Err(Error::InvalidShredVariant),
+            Self::ShredData(ShredData::Legacy(_)) => Err(Error::InvalidShredVariant),
+        }
+    }
 }
 
 // Helper methods to extract pieces of the shred from the payload
@@ -802,7 +833,7 @@ pub mod layout {
         }
     }
 
-    pub(crate) fn set_retransmitter_signature(
+    pub fn set_retransmitter_signature(
         shred: &mut [u8],
         signature: &Signature,
     ) -> Result<(), Error> {

--- a/ledger/src/shred/merkle.rs
+++ b/ledger/src/shred/merkle.rs
@@ -445,7 +445,7 @@ macro_rules! impl_merkle_shred {
             Ok(())
         }
 
-        fn retransmitter_signature_offset(&self) -> Result<usize, Error> {
+        pub(super) fn retransmitter_signature_offset(&self) -> Result<usize, Error> {
             let ShredVariant::$variant {
                 proof_size,
                 chained,

--- a/poh/src/poh_recorder.rs
+++ b/poh/src/poh_recorder.rs
@@ -14,7 +14,9 @@
 use solana_ledger::genesis_utils::{create_genesis_config, GenesisConfigInfo};
 use {
     crate::{leader_bank_notifier::LeaderBankNotifier, poh_service::PohService},
-    crossbeam_channel::{unbounded, Receiver, RecvTimeoutError, SendError, Sender, TrySendError},
+    crossbeam_channel::{
+        bounded, unbounded, Receiver, RecvTimeoutError, SendError, Sender, TrySendError,
+    },
     log::*,
     solana_entry::{
         entry::{hash_transactions, Entry},
@@ -207,7 +209,7 @@ impl TransactionRecorder {
         transactions: Vec<VersionedTransaction>,
     ) -> Result<Option<usize>> {
         // create a new channel so that there is only 1 sender and when it goes out of scope, the receiver fails
-        let (result_sender, result_receiver) = unbounded();
+        let (result_sender, result_receiver) = bounded(1);
         let res =
             self.record_sender
                 .send(Record::new(mixin, transactions, bank_slot, result_sender));

--- a/program-runtime/src/loaded_programs.rs
+++ b/program-runtime/src/loaded_programs.rs
@@ -55,11 +55,6 @@ pub enum BlockRelation {
 pub trait ForkGraph {
     /// Returns the BlockRelation of A to B
     fn relationship(&self, a: Slot, b: Slot) -> BlockRelation;
-
-    /// Returns the epoch of the given slot
-    fn slot_epoch(&self, _slot: Slot) -> Option<Epoch> {
-        Some(0)
-    }
 }
 
 /// The owner of a programs accounts, thus the loader of a program

--- a/program-test/src/lib.rs
+++ b/program-test/src/lib.rs
@@ -56,6 +56,7 @@ use {
         fs::File,
         io::{self, Read},
         mem::transmute,
+        panic::AssertUnwindSafe,
         path::{Path, PathBuf},
         sync::{
             atomic::{AtomicBool, Ordering},
@@ -140,12 +141,25 @@ pub fn invoke_builtin_function(
         unsafe { deserialize(&mut parameter_bytes.as_slice_mut()[0] as *mut u8) };
 
     // Execute the program
-    builtin_function(program_id, &account_infos, input).map_err(|err| {
-        let err = InstructionError::from(u64::from(err));
-        stable_log::program_failure(&log_collector, program_id, &err);
-        let err: Box<dyn std::error::Error> = Box::new(err);
-        err
-    })?;
+    match std::panic::catch_unwind(AssertUnwindSafe(|| {
+        builtin_function(program_id, &account_infos, input)
+    })) {
+        Ok(program_result) => {
+            program_result.map_err(|program_error| {
+                let err = InstructionError::from(u64::from(program_error));
+                stable_log::program_failure(&log_collector, program_id, &err);
+                let err: Box<dyn std::error::Error> = Box::new(err);
+                err
+            })?;
+        }
+        Err(_panic_error) => {
+            let err = InstructionError::ProgramFailedToComplete;
+            stable_log::program_failure(&log_collector, program_id, &err);
+            let err: Box<dyn std::error::Error> = Box::new(err);
+            Err(err)?;
+        }
+    };
+
     stable_log::program_success(&log_collector, program_id);
 
     // Lookup table for AccountInfo
@@ -724,8 +738,6 @@ impl ProgramTest {
 
             // If SBF is not required (i.e., we were invoked with `test`), use the provided
             // processor function as is.
-            //
-            // TODO: figure out why tests hang if a processor panics when running native code.
             (false, _, Some(builtin_function)) => {
                 self.add_builtin_program(program_name, program_id, builtin_function)
             }

--- a/program-test/tests/panic.rs
+++ b/program-test/tests/panic.rs
@@ -1,0 +1,42 @@
+use {
+    solana_program_test::{processor, ProgramTest},
+    solana_sdk::{
+        account_info::AccountInfo,
+        entrypoint::ProgramResult,
+        instruction::{Instruction, InstructionError},
+        pubkey::Pubkey,
+        signature::Signer,
+        transaction::{Transaction, TransactionError},
+    },
+};
+
+fn panic(_program_id: &Pubkey, _accounts: &[AccountInfo], _input: &[u8]) -> ProgramResult {
+    panic!("I panicked");
+}
+
+#[tokio::test]
+async fn panic_test() {
+    let program_id = Pubkey::new_unique();
+
+    let program_test = ProgramTest::new("panic", program_id, processor!(panic));
+
+    let context = program_test.start_with_context().await;
+
+    let instruction = Instruction::new_with_bytes(program_id, &[], vec![]);
+
+    let transaction = Transaction::new_signed_with_payer(
+        &[instruction],
+        Some(&context.payer.pubkey()),
+        &[&context.payer],
+        context.last_blockhash,
+    );
+    assert_eq!(
+        context
+            .banks_client
+            .process_transaction(transaction)
+            .await
+            .unwrap_err()
+            .unwrap(),
+        TransactionError::InstructionError(0, InstructionError::ProgramFailedToComplete)
+    );
+}

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -3731,9 +3731,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -5719,6 +5719,7 @@ dependencies = [
  "solana-sdk",
  "solana-stake-program",
  "solana-svm",
+ "solana-svm-rent-collector",
  "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",
@@ -6453,6 +6454,13 @@ dependencies = [
  "solana-type-overrides",
  "solana-vote",
  "thiserror",
+]
+
+[[package]]
+name = "solana-svm-rent-collector"
+version = "2.1.0"
+dependencies = [
+ "solana-sdk",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -68,6 +68,7 @@ solana-runtime-transaction = { workspace = true }
 solana-sdk = { workspace = true }
 solana-stake-program = { workspace = true }
 solana-svm = { workspace = true }
+solana-svm-rent-collector = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-system-program = { workspace = true }
 solana-timings = { workspace = true }

--- a/runtime/src/bank.rs
+++ b/runtime/src/bank.rs
@@ -43,6 +43,7 @@ use {
         bank_forks::BankForks,
         epoch_stakes::{split_epoch_stakes, EpochStakes, NodeVoteAccounts, VersionedEpochStakes},
         installed_scheduler_pool::{BankWithScheduler, InstalledSchedulerRwLock},
+        rent_collector::RentCollectorWithMetrics,
         runtime_config::RuntimeConfig,
         serde_snapshot::BankIncrementalSnapshotPersistence,
         snapshot_hash::SnapshotHash,
@@ -3476,6 +3477,10 @@ impl Bank {
         timings.saturating_add_in_place(ExecuteTimingType::CheckUs, check_us);
 
         let (blockhash, lamports_per_signature) = self.last_blockhash_and_lamports_per_signature();
+        // TODO: Pass into `TransactionProcessingEnvironment` in place of
+        // `rent_collector` when SVM supports the new `SVMRentCollector` trait.
+        let _rent_collector_with_metrics =
+            RentCollectorWithMetrics::new(self.rent_collector.clone());
         let processing_environment = TransactionProcessingEnvironment {
             blockhash,
             epoch_total_stake: self.epoch_total_stake(self.epoch()),

--- a/runtime/src/bank/tests.rs
+++ b/runtime/src/bank/tests.rs
@@ -101,7 +101,8 @@ use {
     },
     solana_stake_program::stake_state::{self, StakeStateV2},
     solana_svm::{
-        account_loader::LoadedTransaction,
+        account_loader::{FeesOnlyTransaction, LoadedTransaction},
+        rollback_accounts::RollbackAccounts,
         transaction_commit_result::TransactionCommitResultExtensions,
         transaction_execution_result::ExecutedTransaction,
     },
@@ -234,25 +235,27 @@ fn test_race_register_tick_freeze() {
     }
 }
 
-fn new_processing_result(
+fn new_executed_processing_result(
     status: Result<()>,
     fee_details: FeeDetails,
 ) -> TransactionProcessingResult {
-    Ok(ExecutedTransaction {
-        loaded_transaction: LoadedTransaction {
-            fee_details,
-            ..LoadedTransaction::default()
+    Ok(ProcessedTransaction::Executed(Box::new(
+        ExecutedTransaction {
+            loaded_transaction: LoadedTransaction {
+                fee_details,
+                ..LoadedTransaction::default()
+            },
+            execution_details: TransactionExecutionDetails {
+                status,
+                log_messages: None,
+                inner_instructions: None,
+                return_data: None,
+                executed_units: 0,
+                accounts_data_len_delta: 0,
+            },
+            programs_modified_by_tx: HashMap::new(),
         },
-        execution_details: TransactionExecutionDetails {
-            status,
-            log_messages: None,
-            inner_instructions: None,
-            return_data: None,
-            executed_units: 0,
-            accounts_data_len_delta: 0,
-        },
-        programs_modified_by_tx: HashMap::new(),
-    })
+    )))
 }
 
 impl Bank {
@@ -2880,14 +2883,22 @@ fn test_filter_program_errors_and_collect_fee() {
     let tx_fee = 42;
     let fee_details = FeeDetails::new(tx_fee, 0, false);
     let processing_results = vec![
-        new_processing_result(Ok(()), fee_details),
-        new_processing_result(
+        Err(TransactionError::AccountNotFound),
+        new_executed_processing_result(Ok(()), fee_details),
+        new_executed_processing_result(
             Err(TransactionError::InstructionError(
                 1,
                 SystemError::ResultWithNegativeLamports.into(),
             )),
             fee_details,
         ),
+        Ok(ProcessedTransaction::FeesOnly(Box::new(
+            FeesOnlyTransaction {
+                load_error: TransactionError::InvalidProgramForExecution,
+                rollback_accounts: RollbackAccounts::default(),
+                fee_details,
+            },
+        ))),
     ];
     let initial_balance = bank.get_balance(&leader);
 
@@ -2895,7 +2906,7 @@ fn test_filter_program_errors_and_collect_fee() {
     bank.freeze();
     assert_eq!(
         bank.get_balance(&leader),
-        initial_balance + bank.fee_rate_governor.burn(tx_fee * 2).0
+        initial_balance + bank.fee_rate_governor.burn(tx_fee * 3).0
     );
 }
 
@@ -2911,14 +2922,22 @@ fn test_filter_program_errors_and_collect_priority_fee() {
     let priority_fee = 42;
     let fee_details: FeeDetails = FeeDetails::new(0, priority_fee, false);
     let processing_results = vec![
-        new_processing_result(Ok(()), fee_details),
-        new_processing_result(
+        Err(TransactionError::AccountNotFound),
+        new_executed_processing_result(Ok(()), fee_details),
+        new_executed_processing_result(
             Err(TransactionError::InstructionError(
                 1,
                 SystemError::ResultWithNegativeLamports.into(),
             )),
             fee_details,
         ),
+        Ok(ProcessedTransaction::FeesOnly(Box::new(
+            FeesOnlyTransaction {
+                load_error: TransactionError::InvalidProgramForExecution,
+                rollback_accounts: RollbackAccounts::default(),
+                fee_details,
+            },
+        ))),
     ];
     let initial_balance = bank.get_balance(&leader);
 
@@ -2926,7 +2945,7 @@ fn test_filter_program_errors_and_collect_priority_fee() {
     bank.freeze();
     assert_eq!(
         bank.get_balance(&leader),
-        initial_balance + bank.fee_rate_governor.burn(priority_fee * 2).0
+        initial_balance + bank.fee_rate_governor.burn(priority_fee * 3).0
     );
 }
 
@@ -3079,6 +3098,103 @@ fn test_interleaving_locks() {
     assert!(bank
         .transfer(2 * amount, &mint_keypair, &bob.pubkey())
         .is_ok());
+}
+
+#[test_case(false; "disable fees-only transactions")]
+#[test_case(true; "enable fees-only transactions")]
+fn test_load_and_execute_commit_transactions_fees_only(enable_fees_only_txs: bool) {
+    let GenesisConfigInfo {
+        mut genesis_config, ..
+    } = genesis_utils::create_genesis_config(100 * LAMPORTS_PER_SOL);
+    if !enable_fees_only_txs {
+        genesis_config
+            .accounts
+            .remove(&solana_sdk::feature_set::enable_transaction_loading_failure_fees::id());
+    }
+    genesis_config.rent = Rent::default();
+    genesis_config.fee_rate_governor = FeeRateGovernor::new(5000, 0);
+    let (bank, _bank_forks) = Bank::new_with_bank_forks_for_tests(&genesis_config);
+    let bank = Bank::new_from_parent(
+        bank,
+        &Pubkey::new_unique(),
+        genesis_config.epoch_schedule.get_first_slot_in_epoch(1),
+    );
+
+    // Use rent-paying fee payer to show that rent is not collected for fees
+    // only transactions even when they use a rent-paying account.
+    let rent_paying_fee_payer = Pubkey::new_unique();
+    bank.store_account(
+        &rent_paying_fee_payer,
+        &AccountSharedData::new(
+            genesis_config.rent.minimum_balance(0) - 1,
+            0,
+            &system_program::id(),
+        ),
+    );
+
+    // Use nonce to show that loaded account stats also included loaded
+    // nonce account size
+    let nonce_size = nonce::State::size();
+    let nonce_balance = genesis_config.rent.minimum_balance(nonce_size);
+    let nonce_pubkey = Pubkey::new_unique();
+    let nonce_authority = rent_paying_fee_payer;
+    let nonce_initial_hash = DurableNonce::from_blockhash(&Hash::new_unique());
+    let nonce_data = nonce::state::Data::new(nonce_authority, nonce_initial_hash, 5000);
+    let nonce_account = AccountSharedData::new_data(
+        nonce_balance,
+        &nonce::state::Versions::new(nonce::State::Initialized(nonce_data.clone())),
+        &system_program::id(),
+    )
+    .unwrap();
+    bank.store_account(&nonce_pubkey, &nonce_account);
+
+    // Invoke missing program to trigger load error in order to commit a
+    // fees-only transaction
+    let missing_program_id = Pubkey::new_unique();
+    let transaction = Transaction::new_unsigned(Message::new_with_blockhash(
+        &[
+            system_instruction::advance_nonce_account(&nonce_pubkey, &rent_paying_fee_payer),
+            Instruction::new_with_bincode(missing_program_id, &0, vec![]),
+        ],
+        Some(&rent_paying_fee_payer),
+        &nonce_data.blockhash(),
+    ));
+
+    let batch = bank.prepare_batch_for_tests(vec![transaction]);
+    let commit_results = bank
+        .load_execute_and_commit_transactions(
+            &batch,
+            MAX_PROCESSING_AGE,
+            true,
+            ExecutionRecordingConfig::new_single_setting(true),
+            &mut ExecuteTimings::default(),
+            None,
+        )
+        .0;
+
+    if enable_fees_only_txs {
+        assert_eq!(
+            commit_results,
+            vec![Ok(CommittedTransaction {
+                status: Err(TransactionError::ProgramAccountNotFound),
+                log_messages: None,
+                inner_instructions: None,
+                return_data: None,
+                executed_units: 0,
+                fee_details: FeeDetails::new(5000, 0, true),
+                rent_debits: RentDebits::default(),
+                loaded_account_stats: TransactionLoadedAccountsStats {
+                    loaded_accounts_count: 2,
+                    loaded_accounts_data_size: nonce_size as u32,
+                },
+            })]
+        );
+    } else {
+        assert_eq!(
+            commit_results,
+            vec![Err(TransactionError::ProgramAccountNotFound)]
+        );
+    }
 }
 
 #[test]
@@ -6932,6 +7048,15 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         assert!(slot_versions.is_empty());
     }
 
+    // Advance bank to get a new last blockhash so that when we retry invocation
+    // after creating the program, the new transaction created below with the
+    // same `invocation_message` as above doesn't return `AlreadyProcessed` when
+    // processed.
+    goto_end_of_slot(bank.clone());
+    let bank = bank_client
+        .advance_slot(1, bank_forks.as_ref(), &mint_keypair.pubkey())
+        .unwrap();
+
     // Load program file
     let mut file = File::open("../programs/bpf_loader/test_elfs/out/noop_aligned.so")
         .expect("file open failed");
@@ -6997,8 +7122,8 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         let program_cache = bank.transaction_processor.program_cache.read().unwrap();
         let slot_versions = program_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
         assert_eq!(slot_versions.len(), 1);
-        assert_eq!(slot_versions[0].deployment_slot, 0);
-        assert_eq!(slot_versions[0].effective_slot, 0);
+        assert_eq!(slot_versions[0].deployment_slot, bank.slot());
+        assert_eq!(slot_versions[0].effective_slot, bank.slot());
         assert!(matches!(
             slot_versions[0].program,
             ProgramCacheEntryType::Closed,
@@ -7021,8 +7146,8 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         let program_cache = bank.transaction_processor.program_cache.read().unwrap();
         let slot_versions = program_cache.get_slot_versions_for_tests(&buffer_address);
         assert_eq!(slot_versions.len(), 1);
-        assert_eq!(slot_versions[0].deployment_slot, 0);
-        assert_eq!(slot_versions[0].effective_slot, 0);
+        assert_eq!(slot_versions[0].deployment_slot, bank.slot());
+        assert_eq!(slot_versions[0].effective_slot, bank.slot());
         assert!(matches!(
             slot_versions[0].program,
             ProgramCacheEntryType::Closed,
@@ -7123,14 +7248,14 @@ fn test_bpf_loader_upgradeable_deploy_with_max_len() {
         let program_cache = bank.transaction_processor.program_cache.read().unwrap();
         let slot_versions = program_cache.get_slot_versions_for_tests(&program_keypair.pubkey());
         assert_eq!(slot_versions.len(), 2);
-        assert_eq!(slot_versions[0].deployment_slot, 0);
-        assert_eq!(slot_versions[0].effective_slot, 0);
+        assert_eq!(slot_versions[0].deployment_slot, bank.slot() - 1);
+        assert_eq!(slot_versions[0].effective_slot, bank.slot() - 1);
         assert!(matches!(
             slot_versions[0].program,
             ProgramCacheEntryType::Closed,
         ));
-        assert_eq!(slot_versions[1].deployment_slot, 0);
-        assert_eq!(slot_versions[1].effective_slot, 1);
+        assert_eq!(slot_versions[1].deployment_slot, bank.slot() - 1);
+        assert_eq!(slot_versions[1].effective_slot, bank.slot());
         assert!(matches!(
             slot_versions[1].program,
             ProgramCacheEntryType::Loaded(_),
@@ -12772,22 +12897,56 @@ fn test_failed_simulation_compute_units() {
     assert_eq!(expected_consumed_units, simulation.units_consumed);
 }
 
+/// Test that simulations report the load error of fees-only transactions
+#[test]
+fn test_failed_simulation_load_error() {
+    let (genesis_config, mint_keypair) = create_genesis_config(LAMPORTS_PER_SOL);
+    let bank = Bank::new_for_tests(&genesis_config);
+    let (bank, _bank_forks) = bank.wrap_with_bank_forks_for_tests();
+    let missing_program_id = Pubkey::new_unique();
+    let message = Message::new(
+        &[Instruction::new_with_bincode(
+            missing_program_id,
+            &0,
+            vec![],
+        )],
+        Some(&mint_keypair.pubkey()),
+    );
+    let transaction = Transaction::new(&[&mint_keypair], message, bank.last_blockhash());
+
+    bank.freeze();
+    let sanitized = SanitizedTransaction::from_transaction_for_tests(transaction);
+    let simulation = bank.simulate_transaction(&sanitized, false);
+    assert_eq!(
+        simulation,
+        TransactionSimulationResult {
+            result: Err(TransactionError::ProgramAccountNotFound),
+            logs: vec![],
+            post_simulation_accounts: vec![],
+            units_consumed: 0,
+            return_data: None,
+            inner_instructions: None,
+        }
+    );
+}
+
 #[test]
 fn test_filter_program_errors_and_collect_fee_details() {
-    // TX  | EXECUTION RESULT            | COLLECT            | COLLECT
+    // TX  | PROCESSING RESULT           | COLLECT            | COLLECT
     //     |                             | (TX_FEE, PRIO_FEE) | RESULT
     // ---------------------------------------------------------------------------------
-    // tx1 | not executed                | (0    , 0)         | Original Err
-    // tx2 | executed and no error       | (5_000, 1_000)     | Ok
+    // tx1 | not processed               | (0    , 0)         | Original Err
+    // tx2 | processed but not executed  | (5_000, 1_000)     | Ok
     // tx3 | executed has error          | (5_000, 1_000)     | Ok
+    // tx4 | executed and no error       | (5_000, 1_000)     | Ok
     //
     let initial_payer_balance = 7_000;
     let tx_fee = 5000;
     let priority_fee = 1000;
-    let tx_fee_details = FeeDetails::new(tx_fee, priority_fee, false);
+    let fee_details = FeeDetails::new(tx_fee, priority_fee, false);
     let expected_collected_fee_details = CollectorFeeDetails {
-        transaction_fee: 2 * tx_fee,
-        priority_fee: 2 * priority_fee,
+        transaction_fee: 3 * tx_fee,
+        priority_fee: 3 * priority_fee,
     };
 
     let GenesisConfigInfo {
@@ -12799,14 +12958,21 @@ fn test_filter_program_errors_and_collect_fee_details() {
 
     let results = vec![
         Err(TransactionError::AccountNotFound),
-        new_processing_result(Ok(()), tx_fee_details),
-        new_processing_result(
+        Ok(ProcessedTransaction::FeesOnly(Box::new(
+            FeesOnlyTransaction {
+                load_error: TransactionError::InvalidProgramForExecution,
+                rollback_accounts: RollbackAccounts::default(),
+                fee_details,
+            },
+        ))),
+        new_executed_processing_result(
             Err(TransactionError::InstructionError(
                 0,
                 SystemError::ResultWithNegativeLamports.into(),
             )),
-            tx_fee_details,
+            fee_details,
         ),
+        new_executed_processing_result(Ok(()), fee_details),
     ];
 
     bank.filter_program_errors_and_collect_fee_details(&results);

--- a/runtime/src/bank_forks.rs
+++ b/runtime/src/bank_forks.rs
@@ -13,10 +13,7 @@ use {
     log::*,
     solana_measure::measure::Measure,
     solana_program_runtime::loaded_programs::{BlockRelation, ForkGraph},
-    solana_sdk::{
-        clock::{Epoch, Slot},
-        hash::Hash,
-    },
+    solana_sdk::{clock::Slot, hash::Hash},
     std::{
         collections::{hash_map::Entry, HashMap, HashSet},
         ops::Index,
@@ -720,10 +717,6 @@ impl ForkGraph for BankForks {
                     .unwrap_or(BlockRelation::Unrelated)
             })
             .unwrap_or(BlockRelation::Unknown)
-    }
-
-    fn slot_epoch(&self, slot: Slot) -> Option<Epoch> {
-        self.banks.get(&slot).map(|bank| bank.epoch())
     }
 }
 

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -17,6 +17,7 @@ pub mod loader_utils;
 pub mod non_circulating_supply;
 pub mod prioritization_fee;
 pub mod prioritization_fee_cache;
+pub mod rent_collector;
 pub mod root_bank_cache;
 pub mod serde_snapshot;
 pub mod snapshot_archive_info;

--- a/runtime/src/rent_collector.rs
+++ b/runtime/src/rent_collector.rs
@@ -1,0 +1,90 @@
+//! Bank's wrapper around `RentCollector` to allow for overriding of some
+//! `SVMRentCollector` trait methods, which are otherwise implemented on
+//! `RentCollector` directly.
+//!
+//! Agave requires submission of logs and metrics during account rent state
+//! assessment, which is not included in the `RentCollector` implementation
+//! of the `SVMRentCollector` trait. This wrapper allows all `SVMRentCollector`
+//! methods to be passed through to the underlying `RentCollector`, except for
+//! those which require additional logging and metrics.
+
+use {
+    log::*,
+    solana_sdk::{
+        account::AccountSharedData,
+        clock::Epoch,
+        pubkey::Pubkey,
+        rent::{Rent, RentDue},
+        rent_collector::{CollectedInfo, RentCollector},
+        transaction::{Result, TransactionError},
+        transaction_context::IndexOfAccount,
+    },
+    solana_svm_rent_collector::{rent_state::RentState, svm_rent_collector::SVMRentCollector},
+};
+
+/// Wrapper around `RentCollector` to allow for overriding of some
+/// `SVMRentCollector` trait methods, which are otherwise implemented on
+/// `RentCollector` directly.
+///
+/// Overrides inject logging and metrics submission into the rent state
+/// assessment process.
+pub struct RentCollectorWithMetrics(RentCollector);
+
+impl RentCollectorWithMetrics {
+    pub fn new(rent_collector: RentCollector) -> Self {
+        Self(rent_collector)
+    }
+}
+
+impl SVMRentCollector for RentCollectorWithMetrics {
+    fn collect_rent(&self, address: &Pubkey, account: &mut AccountSharedData) -> CollectedInfo {
+        self.0.collect_rent(address, account)
+    }
+
+    fn get_rent(&self) -> &Rent {
+        self.0.get_rent()
+    }
+
+    fn get_rent_due(&self, lamports: u64, data_len: usize, account_rent_epoch: Epoch) -> RentDue {
+        self.0.get_rent_due(lamports, data_len, account_rent_epoch)
+    }
+
+    // Overriden to inject logging and metrics.
+    fn check_rent_state_with_account(
+        &self,
+        pre_rent_state: &RentState,
+        post_rent_state: &RentState,
+        address: &Pubkey,
+        account_state: &AccountSharedData,
+        account_index: IndexOfAccount,
+    ) -> Result<()> {
+        submit_rent_state_metrics(pre_rent_state, post_rent_state);
+        if !solana_sdk::incinerator::check_id(address)
+            && !self.transition_allowed(pre_rent_state, post_rent_state)
+        {
+            debug!(
+                "Account {} not rent exempt, state {:?}",
+                address, account_state,
+            );
+            let account_index = account_index as u8;
+            Err(TransactionError::InsufficientFundsForRent { account_index })
+        } else {
+            Ok(())
+        }
+    }
+}
+
+fn submit_rent_state_metrics(pre_rent_state: &RentState, post_rent_state: &RentState) {
+    match (pre_rent_state, post_rent_state) {
+        (&RentState::Uninitialized, &RentState::RentPaying { .. }) => {
+            inc_new_counter_info!("rent_paying_err-new_account", 1);
+        }
+        (&RentState::RentPaying { .. }, &RentState::RentPaying { .. }) => {
+            inc_new_counter_info!("rent_paying_ok-legacy", 1);
+        }
+        (_, &RentState::RentPaying { .. }) => {
+            inc_new_counter_info!("rent_paying_err-other", 1);
+        }
+        _ => {}
+    }
+}

--- a/sdk/program/src/entrypoint.rs
+++ b/sdk/program/src/entrypoint.rs
@@ -129,7 +129,7 @@ macro_rules! entrypoint {
         pub unsafe extern "C" fn entrypoint(input: *mut u8) -> u64 {
             let (program_id, accounts, instruction_data) =
                 unsafe { $crate::entrypoint::deserialize(input) };
-            match $process_instruction(&program_id, &accounts, &instruction_data) {
+            match $process_instruction(program_id, &accounts, instruction_data) {
                 Ok(()) => $crate::entrypoint::SUCCESS,
                 Err(error) => error.into(),
             }

--- a/sdk/src/feature_set.rs
+++ b/sdk/src/feature_set.rs
@@ -841,6 +841,10 @@ pub mod vote_only_retransmitter_signed_fec_sets {
     solana_sdk::declare_id!("RfEcA95xnhuwooVAhUUksEJLZBF7xKCLuqrJoqk4Zph");
 }
 
+pub mod enable_transaction_loading_failure_fees {
+    solana_sdk::declare_id!("PaymEPK2oqwT9TXAVfadjztH2H6KfLEB9Hhd5Q5frvP");
+}
+
 pub mod enable_turbine_extended_fanout_experiments {
     solana_sdk::declare_id!("BZn14Liea52wtBwrXUxTv6vojuTTmfc7XGEDTXrvMD7b");
 }
@@ -1054,6 +1058,7 @@ lazy_static! {
         (move_stake_and_move_lamports_ixs::id(), "Enable MoveStake and MoveLamports stake program instructions #1610"),
         (ed25519_precompile_verify_strict::id(), "Use strict verification in ed25519 precompile SIMD-0152"),
         (vote_only_retransmitter_signed_fec_sets::id(), "vote only on retransmitter signed fec sets"),
+        (enable_transaction_loading_failure_fees::id(), "Enable fees for some additional transaction failures SIMD-0082"),
         (enable_turbine_extended_fanout_experiments::id(), "enable turbine extended fanout experiments #"),
         (deprecate_legacy_vote_ixs::id(), "Deprecate legacy vote instructions"),
         /*************** ADD NEW FEATURES HERE ***************/

--- a/svm-rent-collector/Cargo.toml
+++ b/svm-rent-collector/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "solana-svm-rent-collector"
+description = "Solana SVM Rent Collector"
+documentation = "https://docs.rs/solana-svm-rent-collector"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-sdk = { workspace = true }

--- a/svm-rent-collector/src/lib.rs
+++ b/svm-rent-collector/src/lib.rs
@@ -1,0 +1,6 @@
+//! Solana SVM Rent Collector.
+//!
+//! Rent management for SVM.
+
+pub mod rent_state;
+pub mod svm_rent_collector;

--- a/svm-rent-collector/src/rent_state.rs
+++ b/svm-rent-collector/src/rent_state.rs
@@ -1,0 +1,15 @@
+//! Account rent state.
+
+/// Rent state of a Solana account.
+#[derive(Debug, PartialEq, Eq)]
+pub enum RentState {
+    /// account.lamports == 0
+    Uninitialized,
+    /// 0 < account.lamports < rent-exempt-minimum
+    RentPaying {
+        lamports: u64,    // account.lamports()
+        data_size: usize, // account.data().len()
+    },
+    /// account.lamports >= rent-exempt-minimum
+    RentExempt,
+}

--- a/svm-rent-collector/src/svm_rent_collector.rs
+++ b/svm-rent-collector/src/svm_rent_collector.rs
@@ -1,0 +1,137 @@
+//! Plugin trait for rent collection within the Solana SVM.
+
+use {
+    crate::rent_state::RentState,
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        clock::Epoch,
+        pubkey::Pubkey,
+        rent::{Rent, RentDue},
+        rent_collector::CollectedInfo,
+        transaction::{Result, TransactionError},
+        transaction_context::{IndexOfAccount, TransactionContext},
+    },
+};
+
+mod rent_collector;
+
+/// Rent collector trait. Represents an entity that can evaluate the rent state
+/// of an account, determine rent due, and collect rent.
+///
+/// Implementors are responsible for evaluating rent due and collecting rent
+/// from accounts, if required. Methods for evaluating account rent state have
+/// default implementations, which can be overridden for customized rent
+/// management.
+pub trait SVMRentCollector {
+    /// Check rent state transition for an account in a transaction.
+    ///
+    /// This method has a default implementation that calls into
+    /// `check_rent_state_with_account`.
+    fn check_rent_state(
+        &self,
+        pre_rent_state: Option<&RentState>,
+        post_rent_state: Option<&RentState>,
+        transaction_context: &TransactionContext,
+        index: IndexOfAccount,
+    ) -> Result<()> {
+        if let Some((pre_rent_state, post_rent_state)) = pre_rent_state.zip(post_rent_state) {
+            let expect_msg =
+                "account must exist at TransactionContext index if rent-states are Some";
+            self.check_rent_state_with_account(
+                pre_rent_state,
+                post_rent_state,
+                transaction_context
+                    .get_key_of_account_at_index(index)
+                    .expect(expect_msg),
+                &transaction_context
+                    .get_account_at_index(index)
+                    .expect(expect_msg)
+                    .borrow(),
+                index,
+            )?;
+        }
+        Ok(())
+    }
+
+    /// Check rent state transition for an account directly.
+    ///
+    /// This method has a default implementation that checks whether the
+    /// transition is allowed and returns an error if it is not. It also
+    /// verifies that the account is not the incinerator.
+    fn check_rent_state_with_account(
+        &self,
+        pre_rent_state: &RentState,
+        post_rent_state: &RentState,
+        address: &Pubkey,
+        _account_state: &AccountSharedData,
+        account_index: IndexOfAccount,
+    ) -> Result<()> {
+        if !solana_sdk::incinerator::check_id(address)
+            && !self.transition_allowed(pre_rent_state, post_rent_state)
+        {
+            let account_index = account_index as u8;
+            Err(TransactionError::InsufficientFundsForRent { account_index })
+        } else {
+            Ok(())
+        }
+    }
+
+    /// Collect rent from an account.
+    fn collect_rent(&self, address: &Pubkey, account: &mut AccountSharedData) -> CollectedInfo;
+
+    /// Determine the rent state of an account.
+    ///
+    /// This method has a default implementation that treats accounts with zero
+    /// lamports as uninitialized and uses the implemented `get_rent` to
+    /// determine whether an account is rent-exempt.
+    fn get_account_rent_state(&self, account: &AccountSharedData) -> RentState {
+        if account.lamports() == 0 {
+            RentState::Uninitialized
+        } else if self
+            .get_rent()
+            .is_exempt(account.lamports(), account.data().len())
+        {
+            RentState::RentExempt
+        } else {
+            RentState::RentPaying {
+                data_size: account.data().len(),
+                lamports: account.lamports(),
+            }
+        }
+    }
+
+    /// Get the rent collector's rent instance.
+    fn get_rent(&self) -> &Rent;
+
+    /// Get the rent due for an account.
+    fn get_rent_due(&self, lamports: u64, data_len: usize, account_rent_epoch: Epoch) -> RentDue;
+
+    /// Check whether a transition from the pre_rent_state to the
+    /// post_rent_state is valid.
+    ///
+    /// This method has a default implementation that allows transitions from
+    /// any state to `RentState::Uninitialized` or `RentState::RentExempt`.
+    /// Pre-state `RentState::RentPaying` can only transition to
+    /// `RentState::RentPaying` if the data size remains the same and the
+    /// account is not credited.
+    fn transition_allowed(&self, pre_rent_state: &RentState, post_rent_state: &RentState) -> bool {
+        match post_rent_state {
+            RentState::Uninitialized | RentState::RentExempt => true,
+            RentState::RentPaying {
+                data_size: post_data_size,
+                lamports: post_lamports,
+            } => {
+                match pre_rent_state {
+                    RentState::Uninitialized | RentState::RentExempt => false,
+                    RentState::RentPaying {
+                        data_size: pre_data_size,
+                        lamports: pre_lamports,
+                    } => {
+                        // Cannot remain RentPaying if resized or credited.
+                        post_data_size == pre_data_size && post_lamports <= pre_lamports
+                    }
+                }
+            }
+        }
+    }
+}

--- a/svm-rent-collector/src/svm_rent_collector/rent_collector.rs
+++ b/svm-rent-collector/src/svm_rent_collector/rent_collector.rs
@@ -1,0 +1,255 @@
+//! Implementation of `SVMRentCollector` for `RentCollector` from the Solana
+//! SDK.
+
+use {
+    crate::svm_rent_collector::SVMRentCollector,
+    solana_sdk::{
+        account::AccountSharedData,
+        clock::Epoch,
+        pubkey::Pubkey,
+        rent::{Rent, RentDue},
+        rent_collector::{CollectedInfo, RentCollector},
+    },
+};
+
+impl SVMRentCollector for RentCollector {
+    fn collect_rent(&self, address: &Pubkey, account: &mut AccountSharedData) -> CollectedInfo {
+        self.collect_from_existing_account(address, account)
+    }
+
+    fn get_rent(&self) -> &Rent {
+        &self.rent
+    }
+
+    fn get_rent_due(&self, lamports: u64, data_len: usize, account_rent_epoch: Epoch) -> RentDue {
+        self.get_rent_due(lamports, data_len, account_rent_epoch)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*,
+        crate::rent_state::RentState,
+        solana_sdk::{
+            account::ReadableAccount,
+            clock::Epoch,
+            epoch_schedule::EpochSchedule,
+            pubkey::Pubkey,
+            transaction::TransactionError,
+            transaction_context::{IndexOfAccount, TransactionContext},
+        },
+    };
+
+    #[test]
+    fn test_get_account_rent_state() {
+        let program_id = Pubkey::new_unique();
+        let uninitialized_account = AccountSharedData::new(0, 0, &Pubkey::default());
+
+        let account_data_size = 100;
+
+        let rent_collector = RentCollector::new(
+            Epoch::default(),
+            EpochSchedule::default(),
+            0.0,
+            Rent::free(),
+        );
+
+        let rent_exempt_account = AccountSharedData::new(1, account_data_size, &program_id); // if rent is free, all accounts with non-zero lamports and non-empty data are rent-exempt
+
+        assert_eq!(
+            rent_collector.get_account_rent_state(&uninitialized_account),
+            RentState::Uninitialized
+        );
+        assert_eq!(
+            rent_collector.get_account_rent_state(&rent_exempt_account),
+            RentState::RentExempt
+        );
+
+        let rent = Rent::default();
+        let rent_minimum_balance = rent.minimum_balance(account_data_size);
+        let rent_paying_account = AccountSharedData::new(
+            rent_minimum_balance.saturating_sub(1),
+            account_data_size,
+            &program_id,
+        );
+        let rent_exempt_account = AccountSharedData::new(
+            rent.minimum_balance(account_data_size),
+            account_data_size,
+            &program_id,
+        );
+        let rent_collector =
+            RentCollector::new(Epoch::default(), EpochSchedule::default(), 0.0, rent);
+
+        assert_eq!(
+            rent_collector.get_account_rent_state(&uninitialized_account),
+            RentState::Uninitialized
+        );
+        assert_eq!(
+            rent_collector.get_account_rent_state(&rent_paying_account),
+            RentState::RentPaying {
+                data_size: account_data_size,
+                lamports: rent_paying_account.lamports(),
+            }
+        );
+        assert_eq!(
+            rent_collector.get_account_rent_state(&rent_exempt_account),
+            RentState::RentExempt
+        );
+    }
+
+    #[test]
+    fn test_transition_allowed() {
+        let rent_collector = RentCollector::default();
+
+        let post_rent_state = RentState::Uninitialized;
+        assert!(rent_collector.transition_allowed(&RentState::Uninitialized, &post_rent_state));
+        assert!(rent_collector.transition_allowed(&RentState::RentExempt, &post_rent_state));
+        assert!(rent_collector.transition_allowed(
+            &RentState::RentPaying {
+                data_size: 0,
+                lamports: 1,
+            },
+            &post_rent_state
+        ));
+
+        let post_rent_state = RentState::RentExempt;
+        assert!(rent_collector.transition_allowed(&RentState::Uninitialized, &post_rent_state));
+        assert!(rent_collector.transition_allowed(&RentState::RentExempt, &post_rent_state));
+        assert!(rent_collector.transition_allowed(
+            &RentState::RentPaying {
+                data_size: 0,
+                lamports: 1,
+            },
+            &post_rent_state
+        ));
+
+        let post_rent_state = RentState::RentPaying {
+            data_size: 2,
+            lamports: 5,
+        };
+
+        // These transitions are not allowed.
+        assert!(!rent_collector.transition_allowed(&RentState::Uninitialized, &post_rent_state));
+        assert!(!rent_collector.transition_allowed(&RentState::RentExempt, &post_rent_state));
+
+        // Transition is not allowed if data size changes.
+        assert!(!rent_collector.transition_allowed(
+            &RentState::RentPaying {
+                data_size: 3,
+                lamports: 5,
+            },
+            &post_rent_state
+        ));
+        assert!(!rent_collector.transition_allowed(
+            &RentState::RentPaying {
+                data_size: 1,
+                lamports: 5,
+            },
+            &post_rent_state
+        ));
+
+        // Transition is always allowed if there is no account data resize or
+        // change in account's lamports.
+        assert!(rent_collector.transition_allowed(
+            &RentState::RentPaying {
+                data_size: 2,
+                lamports: 5,
+            },
+            &post_rent_state
+        ));
+        // Transition is always allowed if there is no account data resize and
+        // account's lamports is reduced.
+        assert!(rent_collector.transition_allowed(
+            &RentState::RentPaying {
+                data_size: 2,
+                lamports: 7,
+            },
+            &post_rent_state
+        ));
+        // Transition is not allowed if the account is credited with more
+        // lamports and remains rent-paying.
+        assert!(!rent_collector.transition_allowed(
+            &RentState::RentPaying {
+                data_size: 2,
+                lamports: 3,
+            },
+            &post_rent_state
+        ));
+    }
+
+    #[test]
+    fn test_check_rent_state_with_account() {
+        let rent_collector = RentCollector::default();
+
+        let pre_rent_state = RentState::RentPaying {
+            data_size: 2,
+            lamports: 3,
+        };
+
+        let post_rent_state = RentState::RentPaying {
+            data_size: 2,
+            lamports: 5,
+        };
+        let account_index = 2 as IndexOfAccount;
+        let key = Pubkey::new_unique();
+        let result = rent_collector.check_rent_state_with_account(
+            &pre_rent_state,
+            &post_rent_state,
+            &key,
+            &AccountSharedData::default(),
+            account_index,
+        );
+        assert_eq!(
+            result.err(),
+            Some(TransactionError::InsufficientFundsForRent {
+                account_index: account_index as u8
+            })
+        );
+
+        let result = rent_collector.check_rent_state_with_account(
+            &pre_rent_state,
+            &post_rent_state,
+            &solana_sdk::incinerator::id(),
+            &AccountSharedData::default(),
+            account_index,
+        );
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_check_rent_state() {
+        let rent_collector = RentCollector::default();
+
+        let context = TransactionContext::new(
+            vec![(Pubkey::new_unique(), AccountSharedData::default())],
+            Rent::default(),
+            20,
+            20,
+        );
+
+        let pre_rent_state = RentState::RentPaying {
+            data_size: 2,
+            lamports: 3,
+        };
+
+        let post_rent_state = RentState::RentPaying {
+            data_size: 2,
+            lamports: 5,
+        };
+
+        let result = rent_collector.check_rent_state(
+            Some(&pre_rent_state),
+            Some(&post_rent_state),
+            &context,
+            0,
+        );
+        assert_eq!(
+            result.err(),
+            Some(TransactionError::InsufficientFundsForRent { account_index: 0 })
+        );
+
+        let result = rent_collector.check_rent_state(None, Some(&post_rent_state), &context, 0);
+        assert!(result.is_ok());
+    }
+}

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -40,6 +40,7 @@ crate-type = ["lib"]
 name = "solana_svm"
 
 [dev-dependencies]
+assert_matches = { workspace = true }
 bincode = { workspace = true }
 lazy_static = { workspace = true }
 libsecp256k1 = { workspace = true }

--- a/svm/src/account_saver.rs
+++ b/svm/src/account_saver.rs
@@ -2,7 +2,8 @@ use {
     crate::{
         rollback_accounts::RollbackAccounts,
         transaction_processing_result::{
-            TransactionProcessingResult, TransactionProcessingResultExtensions,
+            ProcessedTransaction, TransactionProcessingResult,
+            TransactionProcessingResultExtensions,
         },
     },
     solana_sdk::{
@@ -27,12 +28,15 @@ fn max_number_of_accounts_to_collect(
                 .processed_transaction()
                 .map(|processed_tx| (processed_tx, tx))
         })
-        .map(
-            |(processed_tx, tx)| match processed_tx.execution_details.status {
-                Ok(_) => tx.num_write_locks() as usize,
-                Err(_) => processed_tx.loaded_transaction.rollback_accounts.count(),
-            },
-        )
+        .map(|(processed_tx, tx)| match processed_tx {
+            ProcessedTransaction::Executed(executed_tx) => {
+                match executed_tx.execution_details.status {
+                    Ok(_) => tx.num_write_locks() as usize,
+                    Err(_) => executed_tx.loaded_transaction.rollback_accounts.count(),
+                }
+            }
+            ProcessedTransaction::FeesOnly(fees_only_tx) => fees_only_tx.rollback_accounts.count(),
+        })
         .sum()
 }
 
@@ -51,22 +55,36 @@ pub fn collect_accounts_to_store<'a, T: SVMMessage>(
             continue;
         };
 
-        if processed_tx.execution_details.status.is_ok() {
-            collect_accounts_for_successful_tx(
-                &mut accounts,
-                &mut transactions,
-                transaction,
-                &processed_tx.loaded_transaction.accounts,
-            );
-        } else {
-            collect_accounts_for_failed_tx(
-                &mut accounts,
-                &mut transactions,
-                transaction,
-                &mut processed_tx.loaded_transaction.rollback_accounts,
-                durable_nonce,
-                lamports_per_signature,
-            );
+        match processed_tx {
+            ProcessedTransaction::Executed(executed_tx) => {
+                if executed_tx.execution_details.status.is_ok() {
+                    collect_accounts_for_successful_tx(
+                        &mut accounts,
+                        &mut transactions,
+                        transaction,
+                        &executed_tx.loaded_transaction.accounts,
+                    );
+                } else {
+                    collect_accounts_for_failed_tx(
+                        &mut accounts,
+                        &mut transactions,
+                        transaction,
+                        &mut executed_tx.loaded_transaction.rollback_accounts,
+                        durable_nonce,
+                        lamports_per_signature,
+                    );
+                }
+            }
+            ProcessedTransaction::FeesOnly(fees_only_tx) => {
+                collect_accounts_for_failed_tx(
+                    &mut accounts,
+                    &mut transactions,
+                    transaction,
+                    &mut fees_only_tx.rollback_accounts,
+                    durable_nonce,
+                    lamports_per_signature,
+                );
+            }
         }
     }
     (accounts, transactions)
@@ -141,7 +159,7 @@ mod tests {
     use {
         super::*,
         crate::{
-            account_loader::LoadedTransaction,
+            account_loader::{FeesOnlyTransaction, LoadedTransaction},
             nonce_info::NonceInfo,
             transaction_execution_result::{ExecutedTransaction, TransactionExecutionDetails},
         },
@@ -178,22 +196,24 @@ mod tests {
         ))
     }
 
-    fn new_processing_result(
+    fn new_executed_processing_result(
         status: Result<()>,
         loaded_transaction: LoadedTransaction,
     ) -> TransactionProcessingResult {
-        Ok(ExecutedTransaction {
-            execution_details: TransactionExecutionDetails {
-                status,
-                log_messages: None,
-                inner_instructions: None,
-                return_data: None,
-                executed_units: 0,
-                accounts_data_len_delta: 0,
+        Ok(ProcessedTransaction::Executed(Box::new(
+            ExecutedTransaction {
+                execution_details: TransactionExecutionDetails {
+                    status,
+                    log_messages: None,
+                    inner_instructions: None,
+                    return_data: None,
+                    executed_units: 0,
+                    accounts_data_len_delta: 0,
+                },
+                loaded_transaction,
+                programs_modified_by_tx: HashMap::new(),
             },
-            loaded_transaction,
-            programs_modified_by_tx: HashMap::new(),
-        })
+        )))
     }
 
     #[test]
@@ -259,8 +279,8 @@ mod tests {
 
         let txs = vec![tx0.clone(), tx1.clone()];
         let mut processing_results = vec![
-            new_processing_result(Ok(()), loaded0),
-            new_processing_result(Ok(()), loaded1),
+            new_executed_processing_result(Ok(()), loaded0),
+            new_executed_processing_result(Ok(()), loaded1),
         ];
         let max_collected_accounts = max_number_of_accounts_to_collect(&txs, &processing_results);
         assert_eq!(max_collected_accounts, 2);
@@ -280,7 +300,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nonced_failure_accounts_rollback_fee_payer_only() {
+    fn test_collect_accounts_for_failed_tx_rollback_fee_payer_only() {
         let from = keypair_from_seed(&[1; 32]).unwrap();
         let from_address = from.pubkey();
         let to_address = Pubkey::new_unique();
@@ -312,7 +332,7 @@ mod tests {
         };
 
         let txs = vec![tx];
-        let mut processing_results = vec![new_processing_result(
+        let mut processing_results = vec![new_executed_processing_result(
             Err(TransactionError::InstructionError(
                 1,
                 InstructionError::InvalidArgument,
@@ -337,7 +357,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nonced_failure_accounts_rollback_separate_nonce_and_fee_payer() {
+    fn test_collect_accounts_for_failed_tx_rollback_separate_nonce_and_fee_payer() {
         let nonce_address = Pubkey::new_unique();
         let nonce_authority = keypair_from_seed(&[0; 32]).unwrap();
         let from = keypair_from_seed(&[1; 32]).unwrap();
@@ -398,7 +418,7 @@ mod tests {
 
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
         let txs = vec![tx];
-        let mut processing_results = vec![new_processing_result(
+        let mut processing_results = vec![new_executed_processing_result(
             Err(TransactionError::InstructionError(
                 1,
                 InstructionError::InvalidArgument,
@@ -437,7 +457,7 @@ mod tests {
     }
 
     #[test]
-    fn test_nonced_failure_accounts_rollback_same_nonce_and_fee_payer() {
+    fn test_collect_accounts_for_failed_tx_rollback_same_nonce_and_fee_payer() {
         let nonce_authority = keypair_from_seed(&[0; 32]).unwrap();
         let nonce_address = nonce_authority.pubkey();
         let from = keypair_from_seed(&[1; 32]).unwrap();
@@ -496,7 +516,7 @@ mod tests {
 
         let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
         let txs = vec![tx];
-        let mut processing_results = vec![new_processing_result(
+        let mut processing_results = vec![new_executed_processing_result(
             Err(TransactionError::InstructionError(
                 1,
                 InstructionError::InvalidArgument,
@@ -523,5 +543,45 @@ mod tests {
             durable_nonce.as_hash()
         )
         .is_some());
+    }
+
+    #[test]
+    fn test_collect_accounts_for_failed_fees_only_tx() {
+        let from = keypair_from_seed(&[1; 32]).unwrap();
+        let from_address = from.pubkey();
+        let to_address = Pubkey::new_unique();
+
+        let instructions = vec![system_instruction::transfer(&from_address, &to_address, 42)];
+        let message = Message::new(&instructions, Some(&from_address));
+        let blockhash = Hash::new_unique();
+        let tx = new_sanitized_tx(&[&from], message, blockhash);
+
+        let from_account_pre = AccountSharedData::new(4242, 0, &Pubkey::default());
+
+        let txs = vec![tx];
+        let mut processing_results = vec![Ok(ProcessedTransaction::FeesOnly(Box::new(
+            FeesOnlyTransaction {
+                load_error: TransactionError::InvalidProgramForExecution,
+                fee_details: FeeDetails::default(),
+                rollback_accounts: RollbackAccounts::FeePayerOnly {
+                    fee_payer_account: from_account_pre.clone(),
+                },
+            },
+        )))];
+        let max_collected_accounts = max_number_of_accounts_to_collect(&txs, &processing_results);
+        assert_eq!(max_collected_accounts, 1);
+        let durable_nonce = DurableNonce::from_blockhash(&Hash::new_unique());
+        let (collected_accounts, _) =
+            collect_accounts_to_store(&txs, &mut processing_results, &durable_nonce, 0);
+        assert_eq!(collected_accounts.len(), 1);
+        assert_eq!(
+            collected_accounts
+                .iter()
+                .find(|(pubkey, _account)| *pubkey == &from_address)
+                .map(|(_pubkey, account)| *account)
+                .cloned()
+                .unwrap(),
+            from_account_pre,
+        );
     }
 }

--- a/svm/src/rollback_accounts.rs
+++ b/svm/src/rollback_accounts.rs
@@ -79,6 +79,22 @@ impl RollbackAccounts {
             Self::SeparateNonceAndFeePayer { .. } => 2,
         }
     }
+
+    /// Size of accounts tracked for rollback, used when calculating the actual
+    /// cost of transaction processing in the cost model.
+    pub fn data_size(&self) -> usize {
+        match self {
+            Self::FeePayerOnly { fee_payer_account } => fee_payer_account.data().len(),
+            Self::SameNonceAndFeePayer { nonce } => nonce.account().data().len(),
+            Self::SeparateNonceAndFeePayer {
+                nonce,
+                fee_payer_account,
+            } => fee_payer_account
+                .data()
+                .len()
+                .saturating_add(nonce.account().data().len()),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/svm/src/transaction_commit_result.rs
+++ b/svm/src/transaction_commit_result.rs
@@ -9,6 +9,7 @@ use {
 pub type TransactionCommitResult = TransactionResult<CommittedTransaction>;
 
 #[derive(Clone, Debug)]
+#[cfg_attr(feature = "dev-context-only-utils", derive(PartialEq))]
 pub struct CommittedTransaction {
     pub status: TransactionResult<()>,
     pub log_messages: Option<Vec<String>>,

--- a/svm/src/transaction_execution_result.rs
+++ b/svm/src/transaction_execution_result.rs
@@ -7,34 +7,14 @@ pub use solana_sdk::inner_instruction::{InnerInstruction, InnerInstructionsList}
 use {
     crate::account_loader::LoadedTransaction,
     solana_program_runtime::loaded_programs::ProgramCacheEntry,
-    solana_sdk::{
-        pubkey::Pubkey,
-        transaction::{self, TransactionError},
-        transaction_context::TransactionReturnData,
-    },
+    solana_sdk::{pubkey::Pubkey, transaction, transaction_context::TransactionReturnData},
     std::{collections::HashMap, sync::Arc},
 };
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Default, Clone, PartialEq)]
 pub struct TransactionLoadedAccountsStats {
     pub loaded_accounts_data_size: u32,
     pub loaded_accounts_count: usize,
-}
-
-/// Type safe representation of a transaction execution attempt which
-/// differentiates between a transaction that was executed (will be
-/// committed to the ledger) and a transaction which wasn't executed
-/// and will be dropped.
-///
-/// Note: `Result<TransactionExecutionDetails, TransactionError>` is not
-/// used because it's easy to forget that the inner `details.status` field
-/// is what should be checked to detect a successful transaction. This
-/// enum provides a convenience method `Self::was_executed_successfully` to
-/// make such checks hard to do incorrectly.
-#[derive(Debug, Clone)]
-pub enum TransactionExecutionResult {
-    Executed(Box<ExecutedTransaction>),
-    NotExecuted(TransactionError),
 }
 
 #[derive(Debug, Clone)]
@@ -46,7 +26,7 @@ pub struct ExecutedTransaction {
 
 impl ExecutedTransaction {
     pub fn was_successful(&self) -> bool {
-        self.execution_details.status.is_ok()
+        self.execution_details.was_successful()
     }
 }
 

--- a/svm/tests/conformance.rs
+++ b/svm/tests/conformance.rs
@@ -336,9 +336,10 @@ fn run_fixture(fixture: InstrFixture, filename: OsString, execute_as_instr: bool
         return;
     }
 
-    let executed_tx = result.processing_results[0]
+    let processed_tx = result.processing_results[0]
         .processed_transaction()
         .unwrap();
+    let executed_tx = processed_tx.executed_transaction().unwrap();
     let execution_details = &executed_tx.execution_details;
     let loaded_accounts = &executed_tx.loaded_transaction.accounts;
     verify_accounts_and_data(

--- a/svm/tests/integration_test.rs
+++ b/svm/tests/integration_test.rs
@@ -275,6 +275,8 @@ fn svm_integration() {
 
     let executed_tx_0 = result.processing_results[0]
         .processed_transaction()
+        .unwrap()
+        .executed_transaction()
         .unwrap();
     assert!(executed_tx_0.was_successful());
     let logs = executed_tx_0
@@ -286,6 +288,8 @@ fn svm_integration() {
 
     let executed_tx_1 = result.processing_results[1]
         .processed_transaction()
+        .unwrap()
+        .executed_transaction()
         .unwrap();
     assert!(executed_tx_1.was_successful());
 
@@ -301,6 +305,8 @@ fn svm_integration() {
 
     let executed_tx_2 = result.processing_results[2]
         .processed_transaction()
+        .unwrap()
+        .executed_transaction()
         .unwrap();
     let return_data = executed_tx_2
         .execution_details
@@ -314,6 +320,8 @@ fn svm_integration() {
 
     let executed_tx_3 = result.processing_results[3]
         .processed_transaction()
+        .unwrap()
+        .executed_transaction()
         .unwrap();
     assert!(executed_tx_3.execution_details.status.is_err());
     assert!(executed_tx_3

--- a/svm/tests/mock_bank.rs
+++ b/svm/tests/mock_bank.rs
@@ -17,7 +17,7 @@ use {
     solana_sdk::{
         account::{AccountSharedData, ReadableAccount, WritableAccount},
         bpf_loader_upgradeable::{self, UpgradeableLoaderState},
-        clock::{Clock, Epoch, UnixTimestamp},
+        clock::{Clock, UnixTimestamp},
         feature_set::FeatureSet,
         native_loader,
         pubkey::Pubkey,
@@ -48,10 +48,6 @@ impl ForkGraph for MockForkGraph {
             Ordering::Equal => BlockRelation::Equal,
             Ordering::Greater => BlockRelation::Descendant,
         }
-    }
-
-    fn slot_epoch(&self, _slot: Slot) -> Option<Epoch> {
-        Some(0)
     }
 }
 

--- a/transaction-view/src/transaction_meta.rs
+++ b/transaction-view/src/transaction_meta.rs
@@ -1,6 +1,6 @@
 use {
     crate::{
-        address_table_lookup_meta::AddressTableLookupMeta,
+        address_table_lookup_meta::{AddressTableLookupIterator, AddressTableLookupMeta},
         bytes::advance_offset_for_type,
         instructions_meta::{InstructionsIterator, InstructionsMeta},
         message_header_meta::{MessageHeaderMeta, TransactionVersion},
@@ -44,7 +44,7 @@ impl TransactionMeta {
         let instructions = InstructionsMeta::try_new(bytes, &mut offset)?;
         let address_table_lookup = match message_header.version {
             TransactionVersion::Legacy => AddressTableLookupMeta {
-                num_address_table_lookup: 0,
+                num_address_table_lookups: 0,
                 offset: 0,
             },
             TransactionVersion::V0 => AddressTableLookupMeta::try_new(bytes, &mut offset)?,
@@ -102,7 +102,7 @@ impl TransactionMeta {
 
     /// Return the number of address table lookups in the transaction.
     pub fn num_address_table_lookups(&self) -> u8 {
-        self.address_table_lookup.num_address_table_lookup
+        self.address_table_lookup.num_address_table_lookups
     }
 }
 
@@ -201,6 +201,22 @@ impl TransactionMeta {
             index: 0,
         }
     }
+
+    /// Return an iterator over the address table lookups in the transaction.
+    /// # Safety
+    /// - This function must be called with the same `bytes` slice that was
+    ///   used to create the `TransactionMeta` instance.
+    pub unsafe fn address_table_lookup_iter<'a>(
+        &self,
+        bytes: &'a [u8],
+    ) -> AddressTableLookupIterator<'a> {
+        AddressTableLookupIterator {
+            bytes,
+            offset: usize::from(self.address_table_lookup.offset),
+            num_address_table_lookups: self.address_table_lookup.num_address_table_lookups,
+            index: 0,
+        }
+    }
 }
 
 #[cfg(test)]
@@ -246,7 +262,7 @@ mod tests {
             tx.message.instructions().len() as u16
         );
         assert_eq!(
-            meta.address_table_lookup.num_address_table_lookup,
+            meta.address_table_lookup.num_address_table_lookups,
             tx.message
                 .address_table_lookups()
                 .map(|x| x.len() as u8)
@@ -305,7 +321,21 @@ mod tests {
         }
     }
 
-    fn v0_with_lookup() -> VersionedTransaction {
+    fn multiple_transfers() -> VersionedTransaction {
+        let payer = Pubkey::new_unique();
+        VersionedTransaction {
+            signatures: vec![Signature::default()], // 1 signature to be valid.
+            message: VersionedMessage::Legacy(Message::new(
+                &[
+                    system_instruction::transfer(&payer, &Pubkey::new_unique(), 1),
+                    system_instruction::transfer(&payer, &Pubkey::new_unique(), 1),
+                ],
+                Some(&payer),
+            )),
+        }
+    }
+
+    fn v0_with_single_lookup() -> VersionedTransaction {
         let payer = Pubkey::new_unique();
         let to = Pubkey::new_unique();
         VersionedTransaction {
@@ -318,6 +348,36 @@ mod tests {
                         key: Pubkey::new_unique(),
                         addresses: vec![to],
                     }],
+                    Hash::default(),
+                )
+                .unwrap(),
+            ),
+        }
+    }
+
+    fn v0_with_multiple_lookups() -> VersionedTransaction {
+        let payer = Pubkey::new_unique();
+        let to1 = Pubkey::new_unique();
+        let to2 = Pubkey::new_unique();
+        VersionedTransaction {
+            signatures: vec![Signature::default()], // 1 signature to be valid.
+            message: VersionedMessage::V0(
+                v0::Message::try_compile(
+                    &payer,
+                    &[
+                        system_instruction::transfer(&payer, &to1, 1),
+                        system_instruction::transfer(&payer, &to2, 1),
+                    ],
+                    &[
+                        AddressLookupTableAccount {
+                            key: Pubkey::new_unique(),
+                            addresses: vec![to1],
+                        },
+                        AddressLookupTableAccount {
+                            key: Pubkey::new_unique(),
+                            addresses: vec![to2],
+                        },
+                    ],
                     Hash::default(),
                 )
                 .unwrap(),
@@ -342,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_v0_with_lookup() {
-        verify_transaction_view_meta(&v0_with_lookup());
+        verify_transaction_view_meta(&v0_with_single_lookup());
     }
 
     #[test]
@@ -452,7 +512,20 @@ mod tests {
     }
 
     #[test]
-    fn test_instructions_iter() {
+    fn test_instructions_iter_empty() {
+        let tx = minimally_sized_transaction();
+        let bytes = bincode::serialize(&tx).unwrap();
+        let meta = TransactionMeta::try_new(&bytes).unwrap();
+
+        // SAFETY: `bytes` is the same slice used to create `meta`.
+        unsafe {
+            let mut iter = meta.instructions_iter(&bytes);
+            assert!(iter.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_instructions_iter_single() {
         let tx = simple_transfer();
         let bytes = bincode::serialize(&tx).unwrap();
         let meta = TransactionMeta::try_new(&bytes).unwrap();
@@ -467,6 +540,89 @@ mod tests {
                 ix.data,
                 &bincode::serialize(&SystemInstruction::Transfer { lamports: 1 }).unwrap()
             );
+            assert!(iter.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_instructions_iter_multiple() {
+        let tx = multiple_transfers();
+        let bytes = bincode::serialize(&tx).unwrap();
+        let meta = TransactionMeta::try_new(&bytes).unwrap();
+
+        // SAFETY: `bytes` is the same slice used to create `meta`.
+        unsafe {
+            let mut iter = meta.instructions_iter(&bytes);
+            let ix = iter.next().unwrap();
+            assert_eq!(ix.program_id_index, 3);
+            assert_eq!(ix.accounts, &[0, 1]);
+            assert_eq!(
+                ix.data,
+                &bincode::serialize(&SystemInstruction::Transfer { lamports: 1 }).unwrap()
+            );
+            let ix = iter.next().unwrap();
+            assert_eq!(ix.program_id_index, 3);
+            assert_eq!(ix.accounts, &[0, 2]);
+            assert_eq!(
+                ix.data,
+                &bincode::serialize(&SystemInstruction::Transfer { lamports: 1 }).unwrap()
+            );
+            assert!(iter.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_address_table_lookup_iter_empty() {
+        let tx = simple_transfer();
+        let bytes = bincode::serialize(&tx).unwrap();
+        let meta = TransactionMeta::try_new(&bytes).unwrap();
+
+        // SAFETY: `bytes` is the same slice used to create `meta`.
+        unsafe {
+            let mut iter = meta.address_table_lookup_iter(&bytes);
+            assert!(iter.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_address_table_lookup_iter_single() {
+        let tx = v0_with_single_lookup();
+        let bytes = bincode::serialize(&tx).unwrap();
+        let meta = TransactionMeta::try_new(&bytes).unwrap();
+
+        let atls_actual = tx.message.address_table_lookups().unwrap();
+        // SAFETY: `bytes` is the same slice used to create `meta`.
+        unsafe {
+            let mut iter = meta.address_table_lookup_iter(&bytes);
+            let lookup = iter.next().unwrap();
+            assert_eq!(lookup.account_key, &atls_actual[0].account_key);
+            assert_eq!(lookup.writable_indexes, atls_actual[0].writable_indexes);
+            assert_eq!(lookup.readonly_indexes, atls_actual[0].readonly_indexes);
+            assert!(iter.next().is_none());
+        }
+    }
+
+    #[test]
+    fn test_address_table_lookup_iter_multiple() {
+        let tx = v0_with_multiple_lookups();
+        let bytes = bincode::serialize(&tx).unwrap();
+        let meta = TransactionMeta::try_new(&bytes).unwrap();
+
+        let atls_actual = tx.message.address_table_lookups().unwrap();
+        // SAFETY: `bytes` is the same slice used to create `meta`.
+        unsafe {
+            let mut iter = meta.address_table_lookup_iter(&bytes);
+
+            let lookup = iter.next().unwrap();
+            assert_eq!(lookup.account_key, &atls_actual[0].account_key);
+            assert_eq!(lookup.writable_indexes, atls_actual[0].writable_indexes);
+            assert_eq!(lookup.readonly_indexes, atls_actual[0].readonly_indexes);
+
+            let lookup = iter.next().unwrap();
+            assert_eq!(lookup.account_key, &atls_actual[1].account_key);
+            assert_eq!(lookup.writable_indexes, atls_actual[1].writable_indexes);
+            assert_eq!(lookup.readonly_indexes, atls_actual[1].readonly_indexes);
+
             assert!(iter.next().is_none());
         }
     }

--- a/zk-sdk/src/encryption/pod/auth_encryption.rs
+++ b/zk-sdk/src/encryption/pod/auth_encryption.rs
@@ -3,7 +3,10 @@
 #[cfg(not(target_os = "solana"))]
 use crate::{encryption::auth_encryption::AeCiphertext, errors::AuthenticatedEncryptionError};
 use {
-    crate::encryption::{pod::impl_from_str, AE_CIPHERTEXT_LEN},
+    crate::encryption::{
+        pod::{impl_from_bytes, impl_from_str},
+        AE_CIPHERTEXT_LEN,
+    },
     base64::{prelude::BASE64_STANDARD, Engine},
     bytemuck::{Pod, Zeroable},
     std::fmt,
@@ -40,6 +43,8 @@ impl_from_str!(
     BYTES_LEN = AE_CIPHERTEXT_LEN,
     BASE64_LEN = AE_CIPHERTEXT_MAX_BASE64_LEN
 );
+
+impl_from_bytes!(TYPE = PodAeCiphertext, BYTES_LEN = AE_CIPHERTEXT_LEN);
 
 impl Default for PodAeCiphertext {
     fn default() -> Self {

--- a/zk-sdk/src/encryption/pod/elgamal.rs
+++ b/zk-sdk/src/encryption/pod/elgamal.rs
@@ -2,7 +2,8 @@
 
 use {
     crate::encryption::{
-        pod::impl_from_str, DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, ELGAMAL_PUBKEY_LEN,
+        pod::{impl_from_bytes, impl_from_str},
+        DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, ELGAMAL_PUBKEY_LEN,
     },
     base64::{prelude::BASE64_STANDARD, Engine},
     bytemuck::Zeroable,
@@ -52,6 +53,11 @@ impl_from_str!(
     BASE64_LEN = ELGAMAL_CIPHERTEXT_MAX_BASE64_LEN
 );
 
+impl_from_bytes!(
+    TYPE = PodElGamalCiphertext,
+    BYTES_LEN = ELGAMAL_CIPHERTEXT_LEN
+);
+
 #[cfg(not(target_os = "solana"))]
 impl From<ElGamalCiphertext> for PodElGamalCiphertext {
     fn from(decoded_ciphertext: ElGamalCiphertext) -> Self {
@@ -90,6 +96,8 @@ impl_from_str!(
     BYTES_LEN = ELGAMAL_PUBKEY_LEN,
     BASE64_LEN = ELGAMAL_PUBKEY_MAX_BASE64_LEN
 );
+
+impl_from_bytes!(TYPE = PodElGamalPubkey, BYTES_LEN = ELGAMAL_PUBKEY_LEN);
 
 #[cfg(not(target_os = "solana"))]
 impl From<ElGamalPubkey> for PodElGamalPubkey {

--- a/zk-sdk/src/encryption/pod/grouped_elgamal.rs
+++ b/zk-sdk/src/encryption/pod/grouped_elgamal.rs
@@ -5,14 +5,24 @@ use crate::encryption::grouped_elgamal::GroupedElGamalCiphertext;
 use {
     crate::{
         encryption::{
-            pod::{elgamal::PodElGamalCiphertext, pedersen::PodPedersenCommitment},
+            pod::{
+                elgamal::PodElGamalCiphertext, impl_from_bytes, impl_from_str,
+                pedersen::PodPedersenCommitment,
+            },
             DECRYPT_HANDLE_LEN, ELGAMAL_CIPHERTEXT_LEN, PEDERSEN_COMMITMENT_LEN,
         },
         errors::ElGamalError,
     },
+    base64::{prelude::BASE64_STANDARD, Engine},
     bytemuck::Zeroable,
     std::fmt,
 };
+
+/// Maximum length of a base64 encoded grouped ElGamal ciphertext with 2 handles
+const GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES_MAX_BASE64_LEN: usize = 132;
+
+/// Maximum length of a base64 encoded grouped ElGamal ciphertext with 3 handles
+const GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES_MAX_BASE64_LEN: usize = 176;
 
 macro_rules! impl_extract {
     (TYPE = $type:ident) => {
@@ -78,6 +88,18 @@ impl Default for PodGroupedElGamalCiphertext2Handles {
         Self::zeroed()
     }
 }
+
+impl_from_str!(
+    TYPE = PodGroupedElGamalCiphertext2Handles,
+    BYTES_LEN = GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES,
+    BASE64_LEN = GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES_MAX_BASE64_LEN
+);
+
+impl_from_bytes!(
+    TYPE = PodGroupedElGamalCiphertext2Handles,
+    BYTES_LEN = GROUPED_ELGAMAL_CIPHERTEXT_2_HANDLES
+);
+
 #[cfg(not(target_os = "solana"))]
 impl From<GroupedElGamalCiphertext<2>> for PodGroupedElGamalCiphertext2Handles {
     fn from(decoded_ciphertext: GroupedElGamalCiphertext<2>) -> Self {
@@ -114,6 +136,17 @@ impl Default for PodGroupedElGamalCiphertext3Handles {
         Self::zeroed()
     }
 }
+
+impl_from_str!(
+    TYPE = PodGroupedElGamalCiphertext3Handles,
+    BYTES_LEN = GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES,
+    BASE64_LEN = GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES_MAX_BASE64_LEN
+);
+
+impl_from_bytes!(
+    TYPE = PodGroupedElGamalCiphertext3Handles,
+    BYTES_LEN = GROUPED_ELGAMAL_CIPHERTEXT_3_HANDLES
+);
 
 #[cfg(not(target_os = "solana"))]
 impl From<GroupedElGamalCiphertext<3>> for PodGroupedElGamalCiphertext3Handles {

--- a/zk-sdk/src/encryption/pod/mod.rs
+++ b/zk-sdk/src/encryption/pod/mod.rs
@@ -26,3 +26,14 @@ macro_rules! impl_from_str {
     };
 }
 pub(crate) use impl_from_str;
+
+macro_rules! impl_from_bytes {
+    (TYPE = $type:ident, BYTES_LEN = $bytes_len:expr) => {
+        impl std::convert::From<[u8; $bytes_len]> for $type {
+            fn from(bytes: [u8; $bytes_len]) -> Self {
+                Self(bytes)
+            }
+        }
+    };
+}
+pub(crate) use impl_from_bytes;

--- a/zk-sdk/src/encryption/pod/pedersen.rs
+++ b/zk-sdk/src/encryption/pod/pedersen.rs
@@ -1,7 +1,11 @@
 //! Plain Old Data type for the Pedersen commitment scheme.
 
 use {
-    crate::encryption::PEDERSEN_COMMITMENT_LEN,
+    crate::encryption::{
+        pod::{impl_from_bytes, impl_from_str},
+        PEDERSEN_COMMITMENT_LEN,
+    },
+    base64::{prelude::BASE64_STANDARD, Engine},
     bytemuck_derive::{Pod, Zeroable},
     std::fmt,
 };
@@ -10,6 +14,9 @@ use {
     crate::{encryption::pedersen::PedersenCommitment, errors::ElGamalError},
     curve25519_dalek::ristretto::CompressedRistretto,
 };
+
+/// Maximum length of a base64 encoded ElGamal public key
+const PEDERSEN_COMMITMENT_MAX_BASE64_LEN: usize = 44;
 
 /// The `PedersenCommitment` type as a `Pod`.
 #[derive(Clone, Copy, Default, Pod, Zeroable, PartialEq, Eq)]
@@ -28,6 +35,17 @@ impl From<PedersenCommitment> for PodPedersenCommitment {
         Self(decoded_commitment.to_bytes())
     }
 }
+
+impl_from_str!(
+    TYPE = PodPedersenCommitment,
+    BYTES_LEN = PEDERSEN_COMMITMENT_LEN,
+    BASE64_LEN = PEDERSEN_COMMITMENT_MAX_BASE64_LEN
+);
+
+impl_from_bytes!(
+    TYPE = PodPedersenCommitment,
+    BYTES_LEN = PEDERSEN_COMMITMENT_LEN
+);
 
 // For proof verification, interpret pod::PedersenCommitment directly as CompressedRistretto
 #[cfg(not(target_os = "solana"))]


### PR DESCRIPTION
#### Problem
Building on [PR], Bank requires a type that can implement the new `SVMRentCollector` trait, but override `check_rent_state_with_account` in order to inject functionality to submit logs and metrics during rent state evaluation.

#### Summary of Changes
Introduce a wrapper type to the runtime - `RentCollectorWithMetrics` - that simply wraps `RentCollector` and implements `SVMRentCollector` by passing-through the implemented methods to the underlying `RentCollector`. Then implement the override for `check_rent_state_with_account` to submit logs and metrics.
