### PR TITLE
SVM Traces (Light Clients & ZK)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7705,6 +7705,7 @@ version = "2.1.0"
 dependencies = [
  "assert_matches",
  "bincode",
+ "criterion",
  "itertools 0.12.1",
  "lazy_static",
  "libsecp256k1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7754,6 +7754,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-svm-example-light-client"
+version = "2.1.0"
+dependencies = [
+ "solana-bpf-loader-program",
+ "solana-compute-budget",
+ "solana-merkle-tree",
+ "solana-program-runtime",
+ "solana-sdk",
+ "solana-svm",
+ "solana-svm-trace",
+ "solana-svm-transaction",
+ "solana-system-program",
+]
+
+[[package]]
 name = "solana-svm-example-paytube"
 version = "2.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7778,6 +7778,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "solana-svm-trace"
+version = "2.1.0"
+dependencies = [
+ "solana-merkle-tree",
+ "solana-sdk",
+]
+
+[[package]]
 name = "solana-svm-transaction"
 version = "2.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7784,6 +7784,8 @@ version = "2.1.0"
 dependencies = [
  "solana-merkle-tree",
  "solana-sdk",
+ "solana-svm-rent-collector",
+ "solana-svm-transaction",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7734,6 +7734,7 @@ dependencies = [
  "solana-svm",
  "solana-svm-conformance",
  "solana-svm-rent-collector",
+ "solana-svm-trace",
  "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ members = [
     "svm-rent-collector",
     "svm-trace",
     "svm-transaction",
+    "svm/examples/light-client",
     "svm/examples/paytube",
     "test-validator",
     "thin-client",
@@ -435,6 +436,7 @@ solana-storage-proto = { path = "storage-proto", version = "=2.1.0" }
 solana-streamer = { path = "streamer", version = "=2.1.0" }
 solana-svm = { path = "svm", version = "=2.1.0" }
 solana-svm-conformance = { path = "svm-conformance", version = "=2.1.0" }
+solana-svm-example-light-client = { path = "svm/examples/light-client", version = "=2.1.0" }
 solana-svm-example-paytube = { path = "svm/examples/paytube", version = "=2.1.0" }
 solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.1.0" }
 solana-svm-trace = { path = "svm-trace", version = "=2.1.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -120,6 +120,7 @@ members = [
     "svm",
     "svm-conformance",
     "svm-rent-collector",
+    "svm-trace",
     "svm-transaction",
     "svm/examples/paytube",
     "test-validator",
@@ -436,6 +437,7 @@ solana-svm = { path = "svm", version = "=2.1.0" }
 solana-svm-conformance = { path = "svm-conformance", version = "=2.1.0" }
 solana-svm-example-paytube = { path = "svm/examples/paytube", version = "=2.1.0" }
 solana-svm-rent-collector = { path = "svm-rent-collector", version = "=2.1.0" }
+solana-svm-trace = { path = "svm-trace", version = "=2.1.0" }
 solana-svm-transaction = { path = "svm-transaction", version = "=2.1.0" }
 solana-system-program = { path = "programs/system", version = "=2.1.0" }
 solana-test-validator = { path = "test-validator", version = "=2.1.0" }

--- a/merkle-tree/src/merkle_tree.rs
+++ b/merkle-tree/src/merkle_tree.rs
@@ -1,4 +1,4 @@
-use solana_program::hash::{hashv, Hash};
+use solana_program::keccak::{hashv, Hash};
 
 // We need to discern between leaf and intermediate nodes to prevent trivial second
 // pre-image attacks.
@@ -133,6 +133,12 @@ impl MerkleTree {
         }
 
         mt
+    }
+
+    pub fn get_leaf_index(&self, hash: &Hash) -> Option<usize> {
+        self.nodes
+            .get(..self.leaf_count)
+            .and_then(|nodes| nodes.iter().position(|h| h == hash))
     }
 
     pub fn get_root(&self) -> Option<&Hash> {

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6488,6 +6488,8 @@ version = "2.1.0"
 dependencies = [
  "solana-merkle-tree",
  "solana-sdk",
+ "solana-svm-rent-collector",
+ "solana-svm-transaction",
 ]
 
 [[package]]

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -6466,6 +6466,7 @@ dependencies = [
  "solana-runtime-transaction",
  "solana-sdk",
  "solana-svm-rent-collector",
+ "solana-svm-trace",
  "solana-svm-transaction",
  "solana-system-program",
  "solana-timings",
@@ -6478,6 +6479,14 @@ dependencies = [
 name = "solana-svm-rent-collector"
 version = "2.1.0"
 dependencies = [
+ "solana-sdk",
+]
+
+[[package]]
+name = "solana-svm-trace"
+version = "2.1.0"
+dependencies = [
+ "solana-merkle-tree",
  "solana-sdk",
 ]
 

--- a/sdk/program/src/keccak.rs
+++ b/sdk/program/src/keccak.rs
@@ -41,6 +41,9 @@ impl Hasher {
     pub fn result(self) -> Hash {
         Hash(self.hasher.finalize().into())
     }
+    pub fn result_reset(&mut self) -> Hash {
+        Hash(self.hasher.finalize_reset().into())
+    }
 }
 
 impl Sanitize for Hash {}

--- a/svm-trace/Cargo.toml
+++ b/svm-trace/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "solana-svm-trace"
+description = "Solana SVM Trace"
+documentation = "https://docs.rs/solana-svm-trace"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+
+[dependencies]
+solana-merkle-tree = { workspace = true }
+solana-sdk = { workspace = true }

--- a/svm-trace/Cargo.toml
+++ b/svm-trace/Cargo.toml
@@ -12,3 +12,5 @@ edition = { workspace = true }
 [dependencies]
 solana-merkle-tree = { workspace = true }
 solana-sdk = { workspace = true }
+solana-svm-rent-collector = { workspace = true }
+solana-svm-transaction = { workspace = true }

--- a/svm-trace/src/lib.rs
+++ b/svm-trace/src/lib.rs
@@ -1,3 +1,4 @@
 //! Solana SVM Trace.
 
+pub mod receipt;
 pub mod trie;

--- a/svm-trace/src/lib.rs
+++ b/svm-trace/src/lib.rs
@@ -1,0 +1,3 @@
+//! Solana SVM Trace.
+
+pub mod trie;

--- a/svm-trace/src/lib.rs
+++ b/svm-trace/src/lib.rs
@@ -1,4 +1,5 @@
 //! Solana SVM Trace.
 
 pub mod receipt;
+pub mod stf;
 pub mod trie;

--- a/svm-trace/src/receipt.rs
+++ b/svm-trace/src/receipt.rs
@@ -1,0 +1,45 @@
+//! SVM transaction receipt.
+
+use solana_sdk::{
+    fee::FeeDetails, keccak::Hasher, transaction, transaction_context::TransactionReturnData,
+};
+
+/// An SVM transaction receipt. Captures the runtime result of a processed
+/// transaction.
+pub struct SVMTransactionReceipt<'a> {
+    pub compute_units_consumed: &'a u64,
+    pub fee_details: &'a FeeDetails,
+    pub log_messages: Option<&'a Vec<String>>,
+    pub return_data: Option<&'a TransactionReturnData>,
+    pub status: &'a transaction::Result<()>,
+}
+
+pub fn hash_receipt(hasher: &mut Hasher, receipt: &SVMTransactionReceipt) {
+    // `compute_units_consumed`
+    hasher.hash(&receipt.compute_units_consumed.to_le_bytes());
+
+    // `fee_details`
+    hasher.hashv(&[
+        &receipt.fee_details.transaction_fee().to_le_bytes(),
+        &receipt.fee_details.prioritization_fee().to_le_bytes(),
+        // TODO: `remove_rounding_in_fee_calculation` omitted.
+    ]);
+
+    // `log_messages`
+    if let Some(messages) = receipt.log_messages {
+        for m in messages {
+            hasher.hash(m.as_bytes());
+        }
+    }
+
+    // `return_data`
+    if let Some(data) = receipt.return_data {
+        hasher.hashv(&[data.program_id.as_ref(), &data.data]);
+    }
+
+    // `status`
+    hasher.hash(&[match receipt.status {
+        Ok(()) => 0,
+        Err(_) => 1, // TODO: Error codes. Just need to do some integer conversions.
+    }]);
+}

--- a/svm-trace/src/stf.rs
+++ b/svm-trace/src/stf.rs
@@ -1,0 +1,114 @@
+//! SVM STF trace.
+
+use {
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        feature_set::FeatureSet,
+        fee::FeeStructure,
+        keccak::Hasher,
+        pubkey::Pubkey,
+        rent::Rent,
+    },
+    solana_svm_rent_collector::svm_rent_collector::SVMRentCollector,
+    solana_svm_transaction::svm_transaction::SVMTransaction,
+};
+
+pub struct STFState<'a> {
+    pub accounts: &'a [(Pubkey, AccountSharedData)],
+}
+
+pub struct STFEnvironment<'a> {
+    pub feature_set: &'a FeatureSet,
+    pub fee_structure: Option<&'a FeeStructure>,
+    pub lamports_per_signature: &'a u64,
+    pub rent_collector: Option<&'a dyn SVMRentCollector>,
+}
+
+pub struct STFDirective<'a, T: SVMTransaction> {
+    pub environment: &'a STFEnvironment<'a>,
+    pub transaction: &'a T,
+}
+
+pub enum STFTrace<'a, T: SVMTransaction> {
+    State(&'a STFState<'a>),
+    Directive(&'a STFDirective<'a, T>),
+    NewState(&'a STFState<'a>),
+}
+
+pub fn hash_account(hasher: &mut Hasher, pubkey: &Pubkey, account: &AccountSharedData) {
+    hasher.hashv(&[
+        pubkey.as_ref(),
+        account.data(),
+        &account.lamports().to_le_bytes(),
+        account.owner().as_ref(),
+        &[if account.executable() { 1 } else { 0 }],
+        &account.rent_epoch().to_le_bytes(),
+    ]);
+}
+
+fn hash_feature_set(hasher: &mut Hasher, feature_set: &FeatureSet) {
+    // TODO: This is slow...
+    let mut active = feature_set.active.iter().collect::<Vec<_>>();
+    active.sort_by_key(|(k, _)| *k);
+
+    let mut inactive = feature_set.inactive.iter().collect::<Vec<_>>();
+    inactive.sort();
+
+    active
+        .iter()
+        .map(|(k, _)| k)
+        .chain(inactive.iter())
+        .for_each(|feature| {
+            hasher.hash(feature.as_ref());
+        });
+}
+
+fn hash_fee_structure(hasher: &mut Hasher, fee_structure: &FeeStructure) {
+    hasher.hash(&fee_structure.lamports_per_signature.to_le_bytes());
+    hasher.hash(&fee_structure.lamports_per_write_lock.to_le_bytes());
+    // `compute_fee_bins` skipped for now.
+}
+
+fn hash_rent(hasher: &mut Hasher, rent: &Rent) {
+    hasher.hash(&rent.lamports_per_byte_year.to_le_bytes());
+    hasher.hash(&rent.exemption_threshold.to_le_bytes());
+    hasher.hash(&rent.burn_percent.to_le_bytes());
+}
+
+fn hash_rent_collector(hasher: &mut Hasher, rent_collector: &dyn SVMRentCollector) {
+    hash_rent(hasher, rent_collector.get_rent());
+}
+
+pub fn hash_environment(hasher: &mut Hasher, environment: &STFEnvironment) {
+    hash_feature_set(hasher, environment.feature_set);
+    if let Some(fee_structure) = environment.fee_structure {
+        hash_fee_structure(hasher, fee_structure);
+    }
+    hasher.hash(&environment.lamports_per_signature.to_le_bytes());
+    if let Some(rent_collector) = environment.rent_collector {
+        hash_rent_collector(hasher, rent_collector);
+    }
+}
+
+pub fn hash_transaction(hasher: &mut Hasher, transaction: &impl SVMTransaction) {
+    hasher.hash(transaction.signature().as_ref());
+}
+
+pub fn hash_trace<T: SVMTransaction>(hasher: &mut Hasher, trace: &STFTrace<'_, T>) {
+    match trace {
+        STFTrace::State(state) => {
+            for (pubkey, account) in state.accounts {
+                hash_account(hasher, pubkey, account);
+            }
+        }
+        STFTrace::Directive(directive) => {
+            hash_environment(hasher, directive.environment);
+            hash_transaction(hasher, directive.transaction);
+        }
+        STFTrace::NewState(state) => {
+            for (pubkey, account) in state.accounts {
+                hash_account(hasher, pubkey, account);
+            }
+        }
+    }
+}

--- a/svm-trace/src/trie.rs
+++ b/svm-trace/src/trie.rs
@@ -1,0 +1,41 @@
+//! A custom trie structure for storing SVM execution traces.
+//!
+//! TODO: This is a temporary mock-up of the intended data structure.
+//! What we need here is a Merkle-Patricia Trie, which will allow us to add
+//! new entries and re-hash the tree incrementally.
+//!
+//! For now, I've just wrapped a Merkle tree by storing the leaves in a vector,
+//! then calling `merklize` to create a new Merkle tree. Highly inefficient!
+
+use {
+    solana_merkle_tree::MerkleTree,
+    solana_sdk::keccak::{Hash, Hasher},
+};
+
+/// Trie structure for SVM execution traces.
+#[derive(Default)]
+pub struct Trie {
+    hasher: Hasher,
+    // Naive approach - store the leaves, then when finished, create a new
+    // Merkle tree.
+    leaves: Vec<Hash>,
+}
+
+impl Trie {
+    /// Append to the trie.
+    pub fn append(&mut self, hash_fn: impl Fn(&mut Hasher)) {
+        hash_fn(&mut self.hasher);
+        let hash = self.hasher.result_reset();
+        self.leaves.push(hash)
+    }
+
+    /// Push a hash into the trie's leaves.
+    pub fn push(&mut self, hash: Hash) {
+        self.leaves.push(hash);
+    }
+
+    /// Merklize the trie.
+    pub fn merklize(&self) -> MerkleTree {
+        MerkleTree::new(&self.leaves)
+    }
+}

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -28,6 +28,7 @@ solana-program-runtime = { workspace = true }
 solana-runtime-transaction = { workspace = true }
 solana-sdk = { workspace = true }
 solana-svm-rent-collector = { workspace = true }
+solana-svm-trace = { workspace = true }
 solana-svm-transaction = { workspace = true }
 solana-system-program = { workspace = true }
 solana-timings = { workspace = true }

--- a/svm/Cargo.toml
+++ b/svm/Cargo.toml
@@ -42,6 +42,7 @@ name = "solana_svm"
 [dev-dependencies]
 assert_matches = { workspace = true }
 bincode = { workspace = true }
+criterion = { workspace = true }
 lazy_static = { workspace = true }
 libsecp256k1 = { workspace = true }
 prost = { workspace = true }
@@ -81,3 +82,7 @@ shuttle-test = [
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "trace"
+harness = false

--- a/svm/benches/trace.rs
+++ b/svm/benches/trace.rs
@@ -1,0 +1,141 @@
+#[path = "../tests/mock_rollup.rs"]
+mod mock_rollup;
+
+use {
+    criterion::{criterion_group, criterion_main, Criterion},
+    mock_rollup::{
+        mock_bank::{
+            create_executable_environment, register_builtins, MockBankCallback, MockForkGraph,
+        },
+        MockRollup, TraceHandler,
+    },
+    solana_sdk::{
+        instruction::AccountMeta,
+        pubkey::Pubkey,
+        signature::Keypair,
+        signer::Signer,
+        system_instruction,
+        transaction::{SanitizedTransaction, Transaction},
+    },
+    solana_svm::{
+        account_loader::{CheckedTransactionDetails, TransactionCheckResult},
+        transaction_processor::{
+            ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingConfig,
+            TransactionProcessingEnvironment,
+        },
+    },
+    solana_type_overrides::sync::{Arc, RwLock},
+    std::collections::HashSet,
+};
+
+#[derive(Default)]
+struct NoOp;
+impl TraceHandler for NoOp {
+    fn placeholder(&self) {
+        // Placeholder.
+    }
+}
+
+const NUM_RANDOM_ACCOUNT_KEYS: usize = 12;
+
+fn create_transactions(count: usize) -> Vec<SanitizedTransaction> {
+    let alice = Keypair::new();
+    let bob = Pubkey::new_unique();
+    (0..count)
+        .map(|_| {
+            let mut ix = system_instruction::transfer(&alice.pubkey(), &bob, 100);
+            ix.accounts
+                .extend((0..NUM_RANDOM_ACCOUNT_KEYS).map(|_| AccountMeta {
+                    pubkey: Pubkey::new_unique(),
+                    is_signer: false,
+                    is_writable: false,
+                }));
+            let tx = Transaction::new_signed_with_payer(
+                &[ix],
+                Some(&alice.pubkey()),
+                &[&alice],
+                solana_sdk::hash::Hash::default(),
+            );
+            SanitizedTransaction::from_transaction_for_tests(tx)
+        })
+        .collect()
+}
+
+fn create_check_results(count: usize) -> Vec<TransactionCheckResult> {
+    (0..count)
+        .map(|_| {
+            TransactionCheckResult::Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: 0,
+            })
+        })
+        .collect()
+}
+
+fn setup_batch_processor(
+    mock_bank: &MockBankCallback,
+    fork_graph: &Arc<RwLock<MockForkGraph>>,
+) -> TransactionBatchProcessor<MockForkGraph> {
+    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
+        /* slot */ 0,
+        /* epoch */ 0,
+        HashSet::new(),
+    );
+    create_executable_environment(
+        fork_graph.clone(),
+        &mock_bank,
+        &mut batch_processor.program_cache.write().unwrap(),
+    );
+    register_builtins(&mock_bank, &batch_processor);
+    batch_processor
+}
+
+fn trace(c: &mut Criterion) {
+    let rollup_noop = MockRollup::<NoOp>::default();
+
+    let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
+    let batch_processor = setup_batch_processor(rollup_noop.bank(), &fork_graph);
+
+    let processing_environment = TransactionProcessingEnvironment::default();
+    let processing_config = TransactionProcessingConfig {
+        recording_config: ExecutionRecordingConfig {
+            enable_log_recording: true,         // Record logs
+            enable_return_data_recording: true, // Record return data
+            enable_cpi_recording: false,        // Don't care about inner instructions.
+        },
+        ..Default::default()
+    };
+
+    // Bench test against a few transaction sets (empty, small, large, massive).
+    let transaction_sets = vec![
+        ("Empty", create_transactions(0)),
+        ("Small", create_transactions(10)),
+        ("Large", create_transactions(1_000)),
+        ("Massive", create_transactions(100_000)),
+    ];
+    let mut group = c.benchmark_group("SVM Trace Performance");
+
+    for (set_name, transaction_set) in transaction_sets {
+        let santitized_txs = &transaction_set as &[SanitizedTransaction];
+        let check_results = create_check_results(santitized_txs.len());
+
+        // Control.
+        group.bench_function(format!("{} Transaction Batch: Control", set_name), |b| {
+            b.iter(|| {
+                batch_processor.load_and_execute_sanitized_transactions(
+                    &rollup_noop, // No-Op handlers.
+                    santitized_txs,
+                    check_results.clone(),
+                    &processing_environment,
+                    &processing_config,
+                )
+            })
+        });
+    }
+
+    group.finish();
+}
+
+// Criterion main.
+criterion_group!(benches, trace);
+criterion_main!(benches);

--- a/svm/benches/trace.rs
+++ b/svm/benches/trace.rs
@@ -10,12 +10,13 @@ use {
         MockRollup, TraceHandler,
     },
     solana_sdk::{
+        account::AccountSharedData,
         instruction::AccountMeta,
         keccak::Hasher,
         pubkey::Pubkey,
         signature::Keypair,
         signer::Signer,
-        system_instruction,
+        system_instruction, system_program,
         transaction::{SanitizedTransaction, Transaction},
     },
     solana_svm::{
@@ -98,27 +99,50 @@ impl TraceHandler for TransactionSTFTraceHandler {
 
 const NUM_RANDOM_ACCOUNT_KEYS: usize = 12;
 
-fn create_transactions(count: usize) -> Vec<SanitizedTransaction> {
-    let alice = Keypair::new();
-    let bob = Pubkey::new_unique();
-    (0..count)
+fn create_transactions(count: usize, banks: &[&MockBankCallback]) -> Vec<SanitizedTransaction> {
+    let mut accounts_to_store = vec![];
+
+    let payer = Keypair::new();
+    let payer_account = AccountSharedData::new(100_000_000_000, 0, &system_program::id());
+    accounts_to_store.push((payer.pubkey(), payer_account));
+
+    let txs = (0..count)
         .map(|_| {
-            let mut ix = system_instruction::transfer(&alice.pubkey(), &bob, 100);
-            ix.accounts
-                .extend((0..NUM_RANDOM_ACCOUNT_KEYS).map(|_| AccountMeta {
-                    pubkey: Pubkey::new_unique(),
-                    is_signer: false,
-                    is_writable: false,
-                }));
+            let destination = Pubkey::new_unique();
+            let destination_account = AccountSharedData::default();
+            accounts_to_store.push((destination, destination_account));
+
+            let random_accounts = (0..NUM_RANDOM_ACCOUNT_KEYS)
+                .map(|_| (Pubkey::new_unique(), AccountSharedData::default()))
+                .collect::<Vec<_>>();
+            let random_account_metas = random_accounts.iter().map(|(pubkey, _)| AccountMeta {
+                pubkey: *pubkey,
+                is_signer: false,
+                is_writable: false,
+            });
+            accounts_to_store.extend_from_slice(&random_accounts);
+
+            let mut ix = system_instruction::transfer(&payer.pubkey(), &destination, 100);
+            ix.accounts.extend(random_account_metas);
+
             let tx = Transaction::new_signed_with_payer(
                 &[ix],
-                Some(&alice.pubkey()),
-                &[&alice],
+                Some(&payer.pubkey()),
+                &[&payer],
                 solana_sdk::hash::Hash::default(),
             );
             SanitizedTransaction::from_transaction_for_tests(tx)
         })
-        .collect()
+        .collect();
+
+    banks.iter().for_each(|b| {
+        let mut account_store = b.account_shared_data.write().unwrap();
+        accounts_to_store.iter().for_each(|(pubkey, account)| {
+            account_store.insert(*pubkey, account.clone());
+        });
+    });
+
+    txs
 }
 
 fn create_check_results(count: usize) -> Vec<TransactionCheckResult> {
@@ -160,8 +184,6 @@ fn trace(c: &mut Criterion) {
         MockRollup::<TransactionSTFTraceHandler>::default();
 
     let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
-    let batch_processor = setup_batch_processor(rollup_noop.bank(), &fork_graph);
-
     let processing_environment = TransactionProcessingEnvironment::default();
     let processing_config = TransactionProcessingConfig {
         recording_config: ExecutionRecordingConfig {
@@ -174,10 +196,54 @@ fn trace(c: &mut Criterion) {
 
     // Bench test against a few transaction sets (empty, small, large, massive).
     let transaction_sets = vec![
-        ("Empty", create_transactions(0)),
-        ("Small", create_transactions(10)),
-        ("Large", create_transactions(1_000)),
-        ("Massive", create_transactions(100_000)),
+        (
+            "Empty",
+            create_transactions(
+                0,
+                &[
+                    rollup_noop.bank(),
+                    rollup_with_transaction_inclusion_handler.bank(),
+                    rollup_with_transaction_receipt_handler.bank(),
+                    rollup_with_transaction_stf_trace_handler.bank(),
+                ],
+            ),
+        ),
+        (
+            "Small",
+            create_transactions(
+                10,
+                &[
+                    rollup_noop.bank(),
+                    rollup_with_transaction_inclusion_handler.bank(),
+                    rollup_with_transaction_receipt_handler.bank(),
+                    rollup_with_transaction_stf_trace_handler.bank(),
+                ],
+            ),
+        ),
+        (
+            "Large",
+            create_transactions(
+                1_000,
+                &[
+                    rollup_noop.bank(),
+                    rollup_with_transaction_inclusion_handler.bank(),
+                    rollup_with_transaction_receipt_handler.bank(),
+                    rollup_with_transaction_stf_trace_handler.bank(),
+                ],
+            ),
+        ),
+        (
+            "Massive",
+            create_transactions(
+                100_000,
+                &[
+                    rollup_noop.bank(),
+                    rollup_with_transaction_inclusion_handler.bank(),
+                    rollup_with_transaction_receipt_handler.bank(),
+                    rollup_with_transaction_stf_trace_handler.bank(),
+                ],
+            ),
+        ),
     ];
     let mut group = c.benchmark_group("SVM Trace Performance");
 
@@ -186,6 +252,7 @@ fn trace(c: &mut Criterion) {
         let check_results = create_check_results(santitized_txs.len());
 
         // Control.
+        let batch_processor = setup_batch_processor(rollup_noop.bank(), &fork_graph);
         group.bench_function(format!("{} Transaction Batch: Control", set_name), |b| {
             b.iter(|| {
                 batch_processor.load_and_execute_sanitized_transactions(
@@ -199,6 +266,10 @@ fn trace(c: &mut Criterion) {
         });
 
         // With transaction hashing.
+        let batch_processor = setup_batch_processor(
+            rollup_with_transaction_inclusion_handler.bank(),
+            &fork_graph,
+        );
         group.bench_function(
             format!("{} Transaction Batch: With Transaction Hashing", set_name),
             |b| {
@@ -215,6 +286,8 @@ fn trace(c: &mut Criterion) {
         );
 
         // With receipt hashing.
+        let batch_processor =
+            setup_batch_processor(rollup_with_transaction_receipt_handler.bank(), &fork_graph);
         group.bench_function(
             format!("{} Transaction Batch: With Receipt Hashing", set_name),
             |b| {
@@ -231,6 +304,10 @@ fn trace(c: &mut Criterion) {
         );
 
         // With STF trace hashing.
+        let batch_processor = setup_batch_processor(
+            rollup_with_transaction_stf_trace_handler.bank(),
+            &fork_graph,
+        );
         group.bench_function(
             format!("{} Transaction Batch: With STF Trace Hashing", set_name),
             |b| {

--- a/svm/examples/light-client/Cargo.toml
+++ b/svm/examples/light-client/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "solana-svm-example-light-client"
+description = "SVM light client reference example using Solana SVM API"
+version = { workspace = true }
+edition = { workspace = true }
+publish = false
+
+[dependencies]
+solana-bpf-loader-program = { workspace = true }
+solana-compute-budget = { workspace = true }
+solana-merkle-tree = { workspace = true }
+solana-program-runtime = { workspace = true }
+solana-svm = { workspace = true }
+solana-svm-trace = { workspace = true }
+solana-svm-transaction = { workspace = true }
+solana-sdk = { workspace = true }
+solana-system-program = { workspace = true }

--- a/svm/examples/light-client/src/blitz.rs
+++ b/svm/examples/light-client/src/blitz.rs
@@ -1,0 +1,237 @@
+//! Blitz layer 2 blockchain.
+//!
+//! Everything in the `blitz` module is suggested to be what a full node would
+//! run. The full node stores ledger and tree data internally, and exposes
+//! access to proofs created from its tree store through a public API. This can
+//! be considered analogous to the full node's RPC API.
+//!
+//! Blitz very simply packs blocks once the number of processed transactions
+//! has reached some threshold constant. Transactions are processed using the
+//! SVM API.
+//!
+//! Each full node offers a public API for processing tranactions (TPU) and for
+//! requesting proofs from its tree store (RPC).
+
+mod account_store;
+mod batch_processor;
+pub mod blockstore;
+pub mod hash_functions;
+mod trie_store;
+
+use {
+    account_store::BlitzAccountStore,
+    batch_processor::BlitzTransactionBatchProcessor,
+    blockstore::{Block, BlockHeader, BlockRoots},
+    solana_merkle_tree::{merkle_tree::Proof, MerkleTree},
+    solana_sdk::{
+        account::{AccountSharedData, ReadableAccount},
+        clock::Slot,
+        keccak::{Hash, Hasher},
+        pubkey::Pubkey,
+        transaction::{SanitizedTransaction, Transaction},
+    },
+    solana_svm::transaction_processing_callback::TransactionProcessingCallback,
+    solana_svm_trace::{receipt::SVMTransactionReceipt, stf::STFTrace},
+    solana_svm_transaction::svm_transaction::SVMTransaction,
+    std::sync::RwLock,
+    trie_store::{BlitzTreeStore, Merklizer, TreeStoreEntry},
+};
+
+/// Blitz protocol full node.
+pub struct Blitz {
+    /// Account store.
+    account_store: BlitzAccountStore,
+    /// The merklizer for the pending block.
+    merklizer: RwLock<Merklizer>,
+    /// Transaction batch processor (SVM API).
+    processor: BlitzTransactionBatchProcessor,
+    /// The already processed transactions for the pending block, ordered by
+    /// execution.
+    processed_transactions: Vec<Transaction>,
+    /// The current slot.
+    slot: Slot,
+    /// Cached hasher for STF entries.
+    stf_hasher: RwLock<Hasher>,
+    /// Merkle tree store.
+    tree_store: BlitzTreeStore,
+    /// Ledger.
+    pub ledger: Vec<Block>,
+}
+
+impl Blitz {
+    const TRANSACTIONS_PER_BLOCK: usize = 10;
+
+    pub fn add_accounts(&mut self, accounts: &[(Pubkey, AccountSharedData)]) {
+        self.account_store.update(accounts)
+    }
+
+    fn block_space(&self) -> usize {
+        Self::TRANSACTIONS_PER_BLOCK - self.processed_transactions.len()
+    }
+
+    fn get_proof(
+        &self,
+        slot: &Slot,
+        candidate: &Hash,
+        get_tree: impl Fn(&TreeStoreEntry) -> &MerkleTree,
+    ) -> Option<Proof<'_>> {
+        self.tree_store.get(slot).and_then(|trees| {
+            let tree = get_tree(trees);
+            tree.get_leaf_index(candidate)
+                .and_then(|index| tree.find_path(index))
+        })
+    }
+
+    /// Get a transaction inclusion proof from the full node's transaction
+    /// tree.
+    pub fn get_transaction_inclusion_proof(
+        &self,
+        slot: &Slot,
+        candidate: &Hash,
+    ) -> Option<Proof<'_>> {
+        self.get_proof(slot, candidate, |trees| &trees.transactions_tree)
+    }
+
+    /// Get a transaction receipt proof from the full node's receipt tree.
+    pub fn get_transaction_receipt_proof(
+        &self,
+        slot: &Slot,
+        candidate: &Hash,
+    ) -> Option<Proof<'_>> {
+        self.get_proof(slot, candidate, |trees| &trees.receipts_tree)
+    }
+
+    /// Get a STF trace proof from the full node's trace tree.
+    pub fn get_transaction_stf_trace_proof(
+        &self,
+        slot: &Slot,
+        candidate: &Hash,
+    ) -> Option<Proof<'_>> {
+        self.get_proof(slot, candidate, |trees| &trees.traces_tree)
+    }
+
+    fn pack_block(&mut self) {
+        let get_root = |tree: &MerkleTree| tree.get_root().cloned().unwrap_or_default();
+        let trees = std::mem::take(&mut self.merklizer)
+            .into_inner()
+            .unwrap()
+            .merklize();
+
+        let new_block = Block {
+            header: BlockHeader {
+                roots: BlockRoots {
+                    receipts_root: get_root(&trees.receipts_tree),
+                    traces_root: get_root(&trees.traces_tree),
+                    transactions_root: get_root(&trees.transactions_tree),
+                },
+                slot: self.slot,
+            },
+            transactions: std::mem::take(&mut self.processed_transactions),
+        };
+
+        self.ledger.push(new_block);
+        self.tree_store.insert(self.slot, trees);
+
+        self.slot += 1;
+    }
+
+    /// Process a batch of Solana transactions.
+    pub fn process_transactions(&mut self, transactions: &[SanitizedTransaction]) {
+        let mut offset = 0;
+
+        // Chunk batches by `Self::TRANSACTIONS_PER_BLOCK`, creating a new
+        // block per chunk.
+        while offset < transactions.len() {
+            let batch = transactions
+                .get(offset..offset + self.block_space())
+                .unwrap_or(&transactions[offset..]);
+            offset += batch.len();
+
+            // This is a bit weird, but process transactions in each batch one
+            // at a time, so we can update accounts (commit) after each one.
+            for i in 0..batch.len() {
+                self.processor
+                    .process_transaction_batch(self, &batch[i..i + 1])
+                    .processing_results
+                    .iter()
+                    .flatten()
+                    .for_each(|res| {
+                        if let Some(tx) = res.executed_transaction() {
+                            self.account_store.update(&tx.loaded_transaction.accounts);
+                        }
+                    })
+            }
+
+            self.pack_block();
+        }
+    }
+}
+
+impl Default for Blitz {
+    fn default() -> Self {
+        let mut blitz = Self {
+            account_store: BlitzAccountStore::new(),
+            merklizer: RwLock::<Merklizer>::default(),
+            processor: BlitzTransactionBatchProcessor::new(),
+            processed_transactions: Vec::new(),
+            slot: 0,
+            stf_hasher: RwLock::<Hasher>::default(),
+            tree_store: BlitzTreeStore::default(),
+            ledger: Vec::new(),
+        };
+        blitz.processor.add_system_program(&blitz);
+        blitz.account_store.add_system_program();
+        blitz
+    }
+}
+
+// SVM API callback plugin implementation.
+impl TransactionProcessingCallback for Blitz {
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+        self.account_store.get(pubkey).cloned()
+    }
+
+    fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {
+        self.get_account_shared_data(account)
+            .and_then(|account| owners.iter().position(|key| account.owner().eq(key)))
+    }
+
+    // Digest a processed transaction by adding it to the transactions trie.
+    fn digest_processed_transaction(&self, transaction: &impl SVMTransaction) {
+        self.merklizer
+            .write()
+            .unwrap()
+            .transactions_trie
+            .append(|hasher: &mut Hasher| hash_functions::hash_transaction(hasher, transaction));
+    }
+
+    // Digest a processed receipt by adding it to the receipts trie.
+    fn digest_processed_receipt(
+        &self,
+        transaction: &impl SVMTransaction,
+        receipt: &SVMTransactionReceipt,
+    ) {
+        self.merklizer
+            .write()
+            .unwrap()
+            .receipts_trie
+            .append(|hasher: &mut Hasher| {
+                hash_functions::hash_receipt(hasher, transaction, receipt)
+            });
+    }
+
+    // Digest a processed STF trace by adding it to the traces trie.
+    fn digest_processed_stf_trace(&self, trace: &STFTrace<impl SVMTransaction>) {
+        let stf_hasher = &mut *self.stf_hasher.write().unwrap();
+        hash_functions::hash_trace(stf_hasher, trace);
+
+        // Only update the trie when we've received the new state (complete STF hash).
+        if let STFTrace::NewState(_) = trace {
+            self.merklizer
+                .write()
+                .unwrap()
+                .traces_trie
+                .push(stf_hasher.result_reset());
+        }
+    }
+}

--- a/svm/examples/light-client/src/blitz/account_store.rs
+++ b/svm/examples/light-client/src/blitz/account_store.rs
@@ -1,0 +1,38 @@
+//! Simple account store for Blitz accounts.
+
+use {
+    solana_sdk::{account::AccountSharedData, native_loader, pubkey::Pubkey, system_program},
+    std::collections::HashMap,
+};
+
+pub struct BlitzAccountStore {
+    store: HashMap<Pubkey, AccountSharedData>,
+}
+
+impl BlitzAccountStore {
+    pub fn new() -> Self {
+        Self {
+            store: HashMap::new(),
+        }
+    }
+
+    pub fn add_system_program(&mut self) {
+        self.update(&[(
+            system_program::id(),
+            native_loader::create_loadable_account_with_fields("system_program", (5000, 0)),
+        )]);
+    }
+
+    pub fn get(&self, pubkey: &Pubkey) -> Option<&AccountSharedData> {
+        self.store.get(pubkey)
+    }
+
+    pub fn update(&mut self, updated_accounts: &[(Pubkey, AccountSharedData)]) {
+        updated_accounts.iter().for_each(|(pubkey, account)| {
+            self.store
+                .entry(*pubkey)
+                .and_modify(|a| *a = account.clone())
+                .or_insert(account.clone());
+        })
+    }
+}

--- a/svm/examples/light-client/src/blitz/batch_processor.rs
+++ b/svm/examples/light-client/src/blitz/batch_processor.rs
@@ -1,0 +1,134 @@
+//! Wrapper around `TransactionBatchProcessor` to apply defaults, for
+//! simplicity.
+
+use {
+    solana_bpf_loader_program::syscalls::create_program_runtime_environment_v1,
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_program_runtime::loaded_programs::{BlockRelation, ForkGraph, ProgramCacheEntry},
+    solana_sdk::{
+        clock::Slot,
+        feature_set::FeatureSet,
+        fee::FeeStructure,
+        hash::Hash,
+        rent_collector::RentCollector,
+        transaction::{self, SanitizedTransaction},
+    },
+    solana_svm::{
+        account_loader::CheckedTransactionDetails,
+        transaction_processing_callback::TransactionProcessingCallback,
+        transaction_processor::{
+            LoadAndExecuteSanitizedTransactionsOutput, TransactionBatchProcessor,
+            TransactionProcessingConfig, TransactionProcessingEnvironment,
+        },
+    },
+    solana_system_program::system_processor,
+    std::sync::{Arc, RwLock},
+};
+
+struct BlitzForkGraph {}
+
+impl ForkGraph for BlitzForkGraph {
+    fn relationship(&self, _a: Slot, _b: Slot) -> BlockRelation {
+        BlockRelation::Unknown
+    }
+}
+
+fn get_check_results(
+    count: usize,
+    lamports_per_signature: u64,
+) -> Vec<transaction::Result<CheckedTransactionDetails>> {
+    vec![
+        transaction::Result::Ok(CheckedTransactionDetails {
+            nonce: None,
+            lamports_per_signature,
+        });
+        count
+    ]
+}
+
+pub struct BlitzTransactionBatchProcessor {
+    compute_budget: ComputeBudget,
+    feature_set: Arc<FeatureSet>,
+    fee_structure: FeeStructure,
+    #[allow(unused)]
+    fork_graph: Arc<RwLock<BlitzForkGraph>>,
+    lamports_per_signature: u64,
+    processor: TransactionBatchProcessor<BlitzForkGraph>,
+    rent_collector: RentCollector,
+}
+
+impl BlitzTransactionBatchProcessor {
+    pub fn new() -> Self {
+        let compute_budget = ComputeBudget::default();
+        let feature_set = FeatureSet::all_enabled();
+        let fee_structure = FeeStructure::default();
+        let fork_graph = Arc::new(RwLock::new(BlitzForkGraph {}));
+        let lamports_per_signature = fee_structure.lamports_per_signature;
+        let processor = TransactionBatchProcessor::<BlitzForkGraph>::default();
+        let rent_collector = RentCollector::default();
+
+        {
+            let mut cache = processor.program_cache.write().unwrap();
+
+            cache.fork_graph = Some(Arc::downgrade(&fork_graph));
+
+            cache.environments.program_runtime_v1 = Arc::new(
+                create_program_runtime_environment_v1(
+                    &FeatureSet::default(),
+                    &ComputeBudget::default(),
+                    false,
+                    false,
+                )
+                .unwrap(),
+            );
+        }
+
+        Self {
+            compute_budget,
+            feature_set: Arc::new(feature_set),
+            fee_structure,
+            fork_graph,
+            lamports_per_signature,
+            processor,
+            rent_collector,
+        }
+    }
+
+    pub fn add_system_program<CB: TransactionProcessingCallback>(&self, callbacks: &CB) {
+        self.processor.add_builtin(
+            callbacks,
+            solana_system_program::id(),
+            "system_program",
+            ProgramCacheEntry::new_builtin(
+                0,
+                b"system_program".len(),
+                system_processor::Entrypoint::vm,
+            ),
+        );
+    }
+
+    pub fn process_transaction_batch<CB: TransactionProcessingCallback>(
+        &self,
+        account_loader: &CB,
+        batch: &[SanitizedTransaction],
+    ) -> LoadAndExecuteSanitizedTransactionsOutput {
+        self.processor.load_and_execute_sanitized_transactions(
+            account_loader,
+            batch,
+            get_check_results(batch.len(), self.lamports_per_signature),
+            &TransactionProcessingEnvironment {
+                blockhash: Hash::default(),
+                epoch_total_stake: None,
+                epoch_vote_accounts: None,
+                feature_set: Arc::clone(&self.feature_set),
+                fee_structure: Some(&self.fee_structure),
+                lamports_per_signature: self.lamports_per_signature,
+                rent_collector: Some(&self.rent_collector),
+            },
+            &TransactionProcessingConfig {
+                compute_budget: Some(self.compute_budget),
+                ..Default::default()
+            },
+        )
+    }
+}

--- a/svm/examples/light-client/src/blitz/blockstore.rs
+++ b/svm/examples/light-client/src/blitz/blockstore.rs
@@ -1,0 +1,30 @@
+//! The Blitz blockstore. Essentially the structure of Blitz blocks, including
+//! headers.
+
+use solana_sdk::{clock::Slot, keccak::Hash, transaction::Transaction};
+
+/// Merkle roots of the block trees.
+pub struct BlockRoots {
+    /// Merkle root of the block's transaction receipts tree.
+    pub receipts_root: Hash,
+    /// Merkle root of the block's STF traces tree.
+    pub traces_root: Hash,
+    /// Merkle root of the block's transactions tree.
+    pub transactions_root: Hash,
+}
+
+/// A Blitz block headeer.
+pub struct BlockHeader {
+    /// Block roots.
+    pub roots: BlockRoots,
+    /// Slot the block was produced.
+    pub slot: Slot,
+}
+
+/// A Blitz block.
+pub struct Block {
+    /// The block's header.
+    pub header: BlockHeader,
+    /// The block's transactions, ordered by execution.
+    pub transactions: Vec<Transaction>,
+}

--- a/svm/examples/light-client/src/blitz/hash_functions.rs
+++ b/svm/examples/light-client/src/blitz/hash_functions.rs
@@ -1,0 +1,25 @@
+//! Public module for hash functions, so light clients can ensure they're
+//! using the same hashing functions for transaction data.
+
+use {
+    solana_sdk::keccak::Hasher,
+    solana_svm_trace::{receipt::SVMTransactionReceipt, stf::STFTrace},
+    solana_svm_transaction::svm_transaction::SVMTransaction,
+};
+
+pub fn hash_transaction(hasher: &mut Hasher, transaction: &impl SVMTransaction) {
+    hasher.hash(transaction.signature().as_ref());
+}
+
+pub fn hash_receipt(
+    hasher: &mut Hasher,
+    transaction: &impl SVMTransaction,
+    receipt: &SVMTransactionReceipt,
+) {
+    hasher.hash(transaction.signature().as_ref());
+    solana_svm_trace::receipt::hash_receipt(hasher, receipt);
+}
+
+pub fn hash_trace(hasher: &mut Hasher, trace: &STFTrace<impl SVMTransaction>) {
+    solana_svm_trace::stf::hash_trace(hasher, trace);
+}

--- a/svm/examples/light-client/src/blitz/trie_store.rs
+++ b/svm/examples/light-client/src/blitz/trie_store.rs
@@ -1,0 +1,50 @@
+//! Simple trie store for Blitz Merkle-Patricia tries.
+
+use {
+    solana_merkle_tree::MerkleTree, solana_sdk::clock::Slot, solana_svm_trace::trie::Trie,
+    std::collections::HashMap,
+};
+
+#[derive(Default)]
+pub struct Merklizer {
+    /// Merkle-Patricia Trie of transaction receipts.
+    pub receipts_trie: Trie,
+    /// Merkle-Patricia Trie of STF traces.
+    pub traces_trie: Trie,
+    /// Merkle-Patricia Trie of transactions.
+    pub transactions_trie: Trie,
+}
+
+impl Merklizer {
+    pub fn merklize(&self) -> TreeStoreEntry {
+        TreeStoreEntry {
+            receipts_tree: self.receipts_trie.merklize(),
+            traces_tree: self.traces_trie.merklize(),
+            transactions_tree: self.transactions_trie.merklize(),
+        }
+    }
+}
+
+pub struct TreeStoreEntry {
+    /// Merkle tree of transaction receipts.
+    pub receipts_tree: MerkleTree,
+    /// Merkle tree of STF traces.
+    pub traces_tree: MerkleTree,
+    /// Merkle tree of transactions.
+    pub transactions_tree: MerkleTree,
+}
+
+#[derive(Default)]
+pub struct BlitzTreeStore {
+    store: HashMap<Slot, TreeStoreEntry>,
+}
+
+impl BlitzTreeStore {
+    pub fn get(&self, slot: &Slot) -> Option<&TreeStoreEntry> {
+        self.store.get(slot)
+    }
+
+    pub(crate) fn insert(&mut self, slot: Slot, entry: TreeStoreEntry) {
+        self.store.insert(slot, entry);
+    }
+}

--- a/svm/examples/light-client/src/lib.rs
+++ b/svm/examples/light-client/src/lib.rs
@@ -1,0 +1,25 @@
+//! SVM Light Client example.
+//!
+//! This example demonstrates a layer 2 blockchain - Blitz - with an SVM
+//! execution layer. A full node executes transactions using the SVM API, packs
+//! them into blocks, and tracks transactions, transaction receipts, and
+//! transaction STF traces in Merkle trees.
+//!
+//! Everything in the `blitz` module is suggested to be what a full node would
+//! run. The full node stores ledger and tree data internally, and exposes
+//! access to proofs created from its tree store through a public API. This can
+//! be considered analogous to the full node's RPC API.
+//!
+//! The `light_client` module is suggested to be a completely separate client,
+//! which can run on very minimal hardware. The light client tracks only block
+//! headers, and will query full nodes for proofs, which can be used to
+//! validate transactions against the roots stored in each block header.
+//!
+//! Note: This example assumes the light client has some sort of sampling
+//! method for verifying the proper fork slection and each block header's
+//! confirmation.
+//!
+//! To see the full example, check out the tests.
+
+pub mod blitz;
+pub mod light_client;

--- a/svm/examples/light-client/src/light_client.rs
+++ b/svm/examples/light-client/src/light_client.rs
@@ -1,0 +1,120 @@
+//! Blitz light client implementation.
+//!
+//! Many fields on the `Blitz` struct are private, so imagine this light client
+//! actually exists on a completely different machine than some arbitrary full
+//! node running Blitz.
+//!
+//! The `BlitzLightClient` client API takes a reference to a `&Blitz`, however,
+//! in practice, this would be a network connection wherein the light client
+//! makes a request to one or more full nodes (like a sampled subset) for a
+//! proof.
+//!
+//! In many scenarios - such as when a light client asks an RPC for a
+//! transaction's receipt or pre/post state - the light client can immediately
+//! validate the returned data against the roots stored in the block header.
+
+use {
+    crate::blitz::Blitz,
+    solana_sdk::{account::AccountSharedData, clock::Slot, keccak::Hasher, pubkey::Pubkey},
+    solana_svm_trace::{
+        receipt::SVMTransactionReceipt,
+        stf::{STFDirective, STFEnvironment, STFState, STFTrace},
+    },
+    solana_svm_transaction::svm_transaction::SVMTransaction,
+};
+
+pub struct BlitzLightClient<'a> {
+    blitz: &'a Blitz,
+    hasher: &'a mut Hasher,
+}
+
+impl<'a> BlitzLightClient<'a> {
+    pub fn new(blitz: &'a Blitz, hasher: &'a mut Hasher) -> Self {
+        Self { blitz, hasher }
+    }
+
+    /// Prove a transaction's inclusion in a block.
+    ///
+    /// Fetches a transaction inclusion proof from a full node and evaluates it
+    /// against the provided transaction data.
+    pub fn prove_transaction_inclusion(
+        &mut self,
+        slot: &Slot,
+        transaction: &impl SVMTransaction,
+    ) -> bool {
+        let candidate = {
+            crate::blitz::hash_functions::hash_transaction(self.hasher, transaction);
+            let raw_hash = self.hasher.result_reset();
+            self.hasher.hashv(&[&[0], raw_hash.as_ref()]);
+            self.hasher.result_reset()
+        };
+        self.blitz
+            .get_transaction_inclusion_proof(slot, &candidate)
+            .map(|proof| proof.verify(candidate))
+            .unwrap_or(false)
+    }
+
+    /// Prove a transaction's receipt.
+    ///
+    /// Fetches a transaction receipt proof from a full node and evaluates it
+    /// against the provided transaction data.
+    pub fn prove_transaction_receipt(
+        &mut self,
+        slot: &Slot,
+        transaction: &impl SVMTransaction,
+        receipt: &SVMTransactionReceipt,
+    ) -> bool {
+        let candidate = {
+            crate::blitz::hash_functions::hash_receipt(self.hasher, transaction, receipt);
+            let raw_hash = self.hasher.result_reset();
+            self.hasher.hashv(&[&[0], raw_hash.as_ref()]);
+            self.hasher.result_reset()
+        };
+        self.blitz
+            .get_transaction_receipt_proof(slot, &candidate)
+            .map(|proof| proof.verify(candidate))
+            .unwrap_or(false)
+    }
+
+    /// Prove a transaction's state transition function.
+    ///
+    /// Fetches a transaction STF proof from a full node and evaluates it
+    /// against the provided transaction data.
+    pub fn prove_transaction_stf<T: SVMTransaction>(
+        &mut self,
+        slot: &Slot,
+        transaction: &T,
+        environment: &STFEnvironment,
+        pre_account_state: &[(Pubkey, AccountSharedData)],
+        post_account_state: &[(Pubkey, AccountSharedData)],
+    ) -> bool {
+        let candidate = {
+            crate::blitz::hash_functions::hash_trace(
+                self.hasher,
+                &STFTrace::State::<T>(&STFState {
+                    accounts: pre_account_state,
+                }),
+            );
+            crate::blitz::hash_functions::hash_trace(
+                self.hasher,
+                &STFTrace::Directive::<T>(&STFDirective {
+                    environment,
+                    transaction,
+                }),
+            );
+            crate::blitz::hash_functions::hash_trace(
+                self.hasher,
+                &STFTrace::NewState::<T>(&STFState {
+                    accounts: post_account_state,
+                }),
+            );
+            let raw_hash = self.hasher.result_reset();
+            self.hasher.hashv(&[&[0], raw_hash.as_ref()]);
+            self.hasher.result_reset()
+        };
+        self.blitz
+            .get_transaction_stf_trace_proof(slot, &candidate)
+            .map(|proof| proof.verify(candidate))
+            .unwrap_or(false)
+    }
+}

--- a/svm/examples/light-client/tests/blitz.rs
+++ b/svm/examples/light-client/tests/blitz.rs
@@ -1,0 +1,154 @@
+use {
+    solana_sdk::{
+        account::{AccountSharedData, WritableAccount},
+        feature_set::FeatureSet,
+        fee::{FeeDetails, FeeStructure},
+        keccak::Hasher,
+        native_loader,
+        pubkey::Pubkey,
+        rent_collector::RentCollector,
+        signature::Keypair,
+        signer::Signer,
+        system_instruction, system_program,
+        transaction::{SanitizedTransaction, Transaction},
+    },
+    solana_svm_example_light_client::{blitz::Blitz, light_client::BlitzLightClient},
+    solana_svm_trace::{receipt::SVMTransactionReceipt, stf::STFEnvironment},
+};
+
+const ALICE_LAMPORTS: u64 = 100_000_000_000_000_000;
+
+#[test]
+fn blitz() {
+    let alice = Keypair::new();
+    let bob = Pubkey::new_unique();
+    let carol = Pubkey::new_unique();
+
+    // Set up the L2 instance.
+    let mut blitz = Blitz::default();
+    blitz.add_accounts(&[(
+        alice.pubkey(),
+        AccountSharedData::new(ALICE_LAMPORTS, 0, &system_program::id()),
+    )]);
+
+    // All transactions are system transfers here, but it doesn't matter.
+    // We just need to work with the proofs.
+    let transactions = (0..40)
+        .map(|i| {
+            SanitizedTransaction::from_transaction_for_tests(Transaction::new_signed_with_payer(
+                &[system_instruction::transfer(
+                    &alice.pubkey(),
+                    if i % 2 == 0 { &bob } else { &carol },
+                    ALICE_LAMPORTS / 100_000_000 * (i as u64),
+                )],
+                Some(&alice.pubkey()),
+                &[&alice],
+                solana_sdk::hash::Hash::default(),
+            ))
+        })
+        .collect::<Vec<_>>();
+
+    // Process the transactions with the Blitz L2, creating a new block every
+    // time the max transactions per block threshold is reached.
+    blitz.process_transactions(&transactions);
+
+    let mut hasher = Hasher::default();
+    let mut light_client = BlitzLightClient::new(&blitz, &mut hasher);
+
+    // For checks.
+    let system_account_with_lamports = |lamports| {
+        let mut account = AccountSharedData::new(lamports, 0, &system_program::id());
+        account.set_rent_epoch(u64::MAX);
+        account
+    };
+    let system_program_account = || {
+        let mut account = AccountSharedData::new(0, 0, &native_loader::id());
+        account.set_executable(true);
+        account
+    };
+
+    // Select a transaction to evaluate proofs for.
+    // Blitz can support 10 transactions per block, so we know the slot.
+    let slot = 0;
+    let transaction = &transactions[8];
+    assert!(light_client.prove_transaction_inclusion(&slot, transaction));
+    assert!(light_client.prove_transaction_receipt(
+        &slot,
+        transaction,
+        &SVMTransactionReceipt {
+            compute_units_consumed: &150,
+            fee_details: &FeeDetails::new(5000, 0, true),
+            log_messages: None,
+            return_data: None,
+            status: &Ok(()),
+        }
+    ));
+    assert!(light_client.prove_transaction_stf(
+        &slot,
+        transaction,
+        &STFEnvironment {
+            feature_set: &FeatureSet::all_enabled(),
+            fee_structure: Some(&FeeStructure::default()),
+            lamports_per_signature: &FeeStructure::default().lamports_per_signature,
+            rent_collector: Some(&RentCollector::default())
+        },
+        &[
+            (
+                alice.pubkey(),
+                system_account_with_lamports(99999971999955000),
+            ),
+            (bob, system_account_with_lamports(12000000000)),
+            (system_program::id(), system_program_account()),
+        ],
+        &[
+            (
+                alice.pubkey(),
+                system_account_with_lamports(99999963999955000),
+            ),
+            (bob, system_account_with_lamports(20000000000)),
+            (system_program::id(), system_program_account()),
+        ]
+    ));
+
+    // Select another.
+    let slot = 2;
+    let transaction = &transactions[29];
+    assert!(light_client.prove_transaction_inclusion(&slot, transaction));
+    assert!(light_client.prove_transaction_receipt(
+        &slot,
+        transaction,
+        &SVMTransactionReceipt {
+            compute_units_consumed: &150,
+            fee_details: &FeeDetails::new(5000, 0, true),
+            log_messages: None,
+            return_data: None,
+            status: &Ok(()),
+        }
+    ));
+    assert!(light_client.prove_transaction_stf(
+        &slot,
+        transaction,
+        &STFEnvironment {
+            feature_set: &FeatureSet::all_enabled(),
+            fee_structure: Some(&FeeStructure::default()),
+            lamports_per_signature: &FeeStructure::default().lamports_per_signature,
+            rent_collector: Some(&RentCollector::default())
+        },
+        &[
+            (
+                alice.pubkey(),
+                system_account_with_lamports(99999593999850000),
+            ),
+            (carol, system_account_with_lamports(196000000000)),
+            (system_program::id(), system_program_account()),
+        ],
+        &[
+            (
+                alice.pubkey(),
+                system_account_with_lamports(99999564999850000),
+            ),
+            (carol, system_account_with_lamports(225000000000)),
+            (system_program::id(), system_program_account()),
+        ]
+    ));
+}

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,6 +1,6 @@
 use {
     solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
-    solana_svm_trace::receipt::SVMTransactionReceipt,
+    solana_svm_trace::{receipt::SVMTransactionReceipt, stf::STFTrace},
     solana_svm_transaction::svm_transaction::SVMTransaction,
 };
 
@@ -33,6 +33,13 @@ pub trait TransactionProcessingCallback {
         _receipt: &SVMTransactionReceipt,
     ) {
     }
+
+    /// Hook for digesting a processed transactions STF trace during batch
+    /// processing. Only called when a transaction is processed. Transactions
+    /// that fail validation are not passed to digest.
+    ///
+    /// Designed for transaction STF proof generation (light clients).
+    fn digest_processed_stf_trace(&self, _trace: &STFTrace<impl SVMTransaction>) {}
 }
 
 /// The state the account is in initially, before transaction processing

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,5 +1,6 @@
 use {
     solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+    solana_svm_trace::receipt::SVMTransactionReceipt,
     solana_svm_transaction::svm_transaction::SVMTransaction,
 };
 
@@ -20,6 +21,18 @@ pub trait TransactionProcessingCallback {
     ///
     /// Designed for transaction inclusion proof generation (light clients).
     fn digest_processed_transaction(&self, _transaction: &impl SVMTransaction) {}
+
+    /// Hook for digesting a processed transaction receipt during batch
+    /// processing. Only called when a transaction is processed. Transactions
+    /// that fail validation are not passed to digest.
+    ///
+    /// Designed for transaction result proof generation (light clients).
+    fn digest_processed_receipt(
+        &self,
+        _transaction: &impl SVMTransaction,
+        _receipt: &SVMTransactionReceipt,
+    ) {
+    }
 }
 
 /// The state the account is in initially, before transaction processing

--- a/svm/src/transaction_processing_callback.rs
+++ b/svm/src/transaction_processing_callback.rs
@@ -1,4 +1,7 @@
-use solana_sdk::{account::AccountSharedData, pubkey::Pubkey};
+use {
+    solana_sdk::{account::AccountSharedData, pubkey::Pubkey},
+    solana_svm_transaction::svm_transaction::SVMTransaction,
+};
 
 /// Runtime callbacks for transaction processing.
 pub trait TransactionProcessingCallback {
@@ -10,6 +13,13 @@ pub trait TransactionProcessingCallback {
 
     fn inspect_account(&self, _address: &Pubkey, _account_state: AccountState, _is_writable: bool) {
     }
+
+    /// Hook for digesting a processed transaction during batch processing.
+    /// Only called when a transaction is processed. Transactions that fail
+    /// validation are not passed to digest.
+    ///
+    /// Designed for transaction inclusion proof generation (light clients).
+    fn digest_processed_transaction(&self, _transaction: &impl SVMTransaction) {}
 }
 
 /// The state the account is in initially, before transaction processing

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -323,6 +323,9 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                             config,
                         );
 
+                        // Digest the processed transaction.
+                        callbacks.digest_processed_transaction(tx);
+
                         // Update batch specific cache of the loaded programs with the modifications
                         // made by the transaction, if it executed successfully.
                         if executed_tx.was_successful() {

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -50,6 +50,7 @@ use {
         transaction_context::{ExecutionRecord, TransactionContext},
     },
     solana_svm_rent_collector::svm_rent_collector::SVMRentCollector,
+    solana_svm_trace::receipt::SVMTransactionReceipt,
     solana_svm_transaction::{svm_message::SVMMessage, svm_transaction::SVMTransaction},
     solana_timings::{ExecuteTimingType, ExecuteTimings},
     solana_type_overrides::sync::{atomic::Ordering, Arc, RwLock, RwLockReadGuard},
@@ -325,6 +326,20 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
                         // Digest the processed transaction.
                         callbacks.digest_processed_transaction(tx);
+
+                        // Digest the procssed transaction receipt.
+                        callbacks.digest_processed_receipt(
+                            tx,
+                            &SVMTransactionReceipt {
+                                compute_units_consumed: &executed_tx
+                                    .execution_details
+                                    .executed_units,
+                                fee_details: &executed_tx.loaded_transaction.fee_details,
+                                log_messages: executed_tx.execution_details.log_messages.as_ref(),
+                                return_data: executed_tx.execution_details.return_data.as_ref(),
+                                status: &executed_tx.execution_details.status,
+                            },
+                        );
 
                         // Update batch specific cache of the loaded programs with the modifications
                         // made by the transaction, if it executed successfully.

--- a/svm/src/transaction_processor.rs
+++ b/svm/src/transaction_processor.rs
@@ -50,7 +50,10 @@ use {
         transaction_context::{ExecutionRecord, TransactionContext},
     },
     solana_svm_rent_collector::svm_rent_collector::SVMRentCollector,
-    solana_svm_trace::receipt::SVMTransactionReceipt,
+    solana_svm_trace::{
+        receipt::SVMTransactionReceipt,
+        stf::{STFDirective, STFEnvironment, STFState, STFTrace},
+    },
     solana_svm_transaction::{svm_message::SVMMessage, svm_transaction::SVMTransaction},
     solana_timings::{ExecuteTimingType, ExecuteTimings},
     solana_type_overrides::sync::{atomic::Ordering, Arc, RwLock, RwLockReadGuard},
@@ -226,10 +229,13 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
     }
 
     /// Main entrypoint to the SVM.
-    pub fn load_and_execute_sanitized_transactions<CB: TransactionProcessingCallback>(
+    pub fn load_and_execute_sanitized_transactions<
+        CB: TransactionProcessingCallback,
+        T: SVMTransaction,
+    >(
         &self,
         callbacks: &CB,
-        sanitized_txs: &[impl SVMTransaction],
+        sanitized_txs: &[T],
         check_results: Vec<TransactionCheckResult>,
         environment: &TransactionProcessingEnvironment,
         config: &TransactionProcessingConfig,
@@ -314,6 +320,40 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
                         }
                     }
                     TransactionLoadResult::Loaded(loaded_transaction) => {
+                        // ::[STF]::
+                        //
+                        // At this point, a transaction was successfully loaded, so the SVM now
+                        // has all the required inputs to process the transaction. The below
+                        // seection can be considered the transaction's State Transition Function
+                        // (STF).
+                        //
+                        // STF current state S is the account state before the transaction is
+                        // executed.
+                        //
+                        // STF directive (D) is both the transaction as well as the SVM's
+                        // provisioned environment (`TransactionProcessingEnvironment`).
+                        //
+                        // STF resulting state S' is the account state after the transaction is
+                        // executed.
+                        //
+                        //     S' = fn( S, D ) where fn is SVM.
+
+                        // ::[STF]:: Current state.
+                        callbacks.digest_processed_stf_trace(&STFTrace::State::<T>(&STFState {
+                            accounts: &loaded_transaction.accounts,
+                        }));
+
+                        // ::[STF]:: Directive.
+                        callbacks.digest_processed_stf_trace(&STFTrace::Directive(&STFDirective {
+                            environment: &STFEnvironment {
+                                feature_set: &environment.feature_set,
+                                fee_structure: environment.fee_structure,
+                                lamports_per_signature: &environment.lamports_per_signature,
+                                rent_collector: environment.rent_collector,
+                            },
+                            transaction: tx,
+                        }));
+
                         let executed_tx = self.execute_loaded_transaction(
                             tx,
                             loaded_transaction,
@@ -326,6 +366,11 @@ impl<FG: ForkGraph> TransactionBatchProcessor<FG> {
 
                         // Digest the processed transaction.
                         callbacks.digest_processed_transaction(tx);
+
+                        // ::[STF]:: New state.
+                        callbacks.digest_processed_stf_trace(&STFTrace::NewState::<T>(&STFState {
+                            accounts: &executed_tx.loaded_transaction.accounts,
+                        }));
 
                         // Digest the procssed transaction receipt.
                         callbacks.digest_processed_receipt(

--- a/svm/tests/mock_rollup.rs
+++ b/svm/tests/mock_rollup.rs
@@ -13,7 +13,7 @@ use {
         signature::Signature,
     },
     solana_svm::transaction_processing_callback::{AccountState, TransactionProcessingCallback},
-    solana_svm_trace::receipt::SVMTransactionReceipt,
+    solana_svm_trace::{receipt::SVMTransactionReceipt, stf::STFTrace},
     solana_svm_transaction::svm_transaction::SVMTransaction,
 };
 
@@ -22,6 +22,7 @@ use {
 pub trait TraceHandler: Default {
     fn digest_transaction(&self, transaction: &impl SVMTransaction);
     fn digest_receipt(&self, transaction: &impl SVMTransaction, receipt: &SVMTransactionReceipt);
+    fn digest_trace(&self, trace: &STFTrace<impl SVMTransaction>);
 }
 
 // All the setup is done on `MockRollup`, and we can customize some of the
@@ -108,5 +109,10 @@ where
         receipt: &SVMTransactionReceipt,
     ) {
         self.trace_handler.digest_receipt(transaction, receipt);
+    }
+
+    // Override.
+    fn digest_processed_stf_trace(&self, trace: &STFTrace<impl SVMTransaction>) {
+        self.trace_handler.digest_trace(trace);
     }
 }

--- a/svm/tests/mock_rollup.rs
+++ b/svm/tests/mock_rollup.rs
@@ -1,0 +1,96 @@
+//! A mockup implementation - similar to MockBankCallback - that can be used to
+//! test against the SVM API. Specifically tailored to the traces feature,
+//! considering the `TraceHandler` trait.
+#![allow(unused)]
+
+#[path = "./mock_bank.rs"]
+pub mod mock_bank;
+
+use {
+    mock_bank::MockBankCallback,
+    solana_sdk::{
+        account::AccountSharedData, pubkey::Pubkey, rent_collector::RentCollector,
+        signature::Signature,
+    },
+    solana_svm::transaction_processing_callback::{AccountState, TransactionProcessingCallback},
+    solana_svm_transaction::svm_transaction::SVMTransaction,
+};
+
+// Plugin trait to let each test case define its own "handler" hooks, without
+// having to go through all of the annoying setup below.
+pub trait TraceHandler: Default {
+    fn placeholder(&self);
+}
+
+// All the setup is done on `MockRollup`, and we can customize some of the
+// callbacks through the plugin trait above.
+#[derive(Default)]
+pub struct MockRollup<R>
+where
+    R: TraceHandler,
+{
+    bank: MockBankCallback,
+    rent_collector: RentCollector,
+    trace_handler: R,
+}
+
+impl<R> MockRollup<R>
+where
+    R: TraceHandler,
+{
+    pub fn bank(&self) -> &MockBankCallback {
+        &self.bank
+    }
+
+    pub fn rent_collector(&self) -> &RentCollector {
+        &self.rent_collector
+    }
+
+    pub fn trace_handler(&self) -> &R {
+        &self.trace_handler
+    }
+
+    pub fn add_rent_exempt_account(
+        &self,
+        pubkey: &Pubkey,
+        data: &[u8],
+        owner: &Pubkey,
+        excess_lamports: u64,
+    ) {
+        let space = data.len();
+        let lamports = self
+            .rent_collector
+            .rent
+            .minimum_balance(space)
+            .saturating_add(excess_lamports);
+        let mut account = AccountSharedData::new(lamports, space, owner);
+        account.set_data_from_slice(data);
+        self.bank
+            .account_shared_data
+            .write()
+            .unwrap()
+            .insert(*pubkey, account);
+    }
+}
+
+impl<R> TransactionProcessingCallback for MockRollup<R>
+where
+    R: TraceHandler,
+{
+    fn account_matches_owners(&self, account: &Pubkey, owners: &[Pubkey]) -> Option<usize> {
+        self.bank.account_matches_owners(account, owners)
+    }
+
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<AccountSharedData> {
+        self.bank.get_account_shared_data(pubkey)
+    }
+
+    fn add_builtin_account(&self, name: &str, program_id: &Pubkey) {
+        self.bank.add_builtin_account(name, program_id)
+    }
+
+    fn inspect_account(&self, address: &Pubkey, account_state: AccountState, is_writable: bool) {
+        self.bank
+            .inspect_account(address, account_state, is_writable)
+    }
+}

--- a/svm/tests/mock_rollup.rs
+++ b/svm/tests/mock_rollup.rs
@@ -13,6 +13,7 @@ use {
         signature::Signature,
     },
     solana_svm::transaction_processing_callback::{AccountState, TransactionProcessingCallback},
+    solana_svm_trace::receipt::SVMTransactionReceipt,
     solana_svm_transaction::svm_transaction::SVMTransaction,
 };
 
@@ -20,6 +21,7 @@ use {
 // having to go through all of the annoying setup below.
 pub trait TraceHandler: Default {
     fn digest_transaction(&self, transaction: &impl SVMTransaction);
+    fn digest_receipt(&self, transaction: &impl SVMTransaction, receipt: &SVMTransactionReceipt);
 }
 
 // All the setup is done on `MockRollup`, and we can customize some of the
@@ -97,5 +99,14 @@ where
     // Override.
     fn digest_processed_transaction(&self, transaction: &impl SVMTransaction) {
         self.trace_handler.digest_transaction(transaction);
+    }
+
+    // Override.
+    fn digest_processed_receipt(
+        &self,
+        transaction: &impl SVMTransaction,
+        receipt: &SVMTransactionReceipt,
+    ) {
+        self.trace_handler.digest_receipt(transaction, receipt);
     }
 }

--- a/svm/tests/mock_rollup.rs
+++ b/svm/tests/mock_rollup.rs
@@ -19,7 +19,7 @@ use {
 // Plugin trait to let each test case define its own "handler" hooks, without
 // having to go through all of the annoying setup below.
 pub trait TraceHandler: Default {
-    fn placeholder(&self);
+    fn digest_transaction(&self, transaction: &impl SVMTransaction);
 }
 
 // All the setup is done on `MockRollup`, and we can customize some of the
@@ -92,5 +92,10 @@ where
     fn inspect_account(&self, address: &Pubkey, account_state: AccountState, is_writable: bool) {
         self.bank
             .inspect_account(address, account_state, is_writable)
+    }
+
+    // Override.
+    fn digest_processed_transaction(&self, transaction: &impl SVMTransaction) {
+        self.trace_handler.digest_transaction(transaction);
     }
 }

--- a/svm/tests/trace.rs
+++ b/svm/tests/trace.rs
@@ -1,0 +1,259 @@
+mod mock_rollup;
+
+use {
+    mock_rollup::{
+        mock_bank::{
+            create_executable_environment, register_builtins, MockBankCallback, MockForkGraph,
+        },
+        MockRollup, TraceHandler,
+    },
+    solana_program_runtime::loaded_programs::ProgramCacheEntry,
+    solana_sdk::{
+        instruction::{AccountMeta, Instruction},
+        pubkey::Pubkey,
+        signature::Keypair,
+        signer::Signer,
+        system_instruction, system_program,
+        transaction::{SanitizedTransaction, Transaction},
+    },
+    solana_svm::{
+        account_loader::{CheckedTransactionDetails, TransactionCheckResult},
+        transaction_processor::{
+            ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingConfig,
+            TransactionProcessingEnvironment,
+        },
+    },
+    solana_type_overrides::sync::{Arc, RwLock},
+    std::collections::HashSet,
+};
+
+fn create_check_results(count: usize) -> Vec<TransactionCheckResult> {
+    (0..count)
+        .map(|_| {
+            TransactionCheckResult::Ok(CheckedTransactionDetails {
+                nonce: None,
+                lamports_per_signature: 0,
+            })
+        })
+        .collect()
+}
+
+fn setup_batch_processor(
+    mock_bank: &MockBankCallback,
+    fork_graph: &Arc<RwLock<MockForkGraph>>,
+) -> TransactionBatchProcessor<MockForkGraph> {
+    let batch_processor = TransactionBatchProcessor::<MockForkGraph>::new(
+        /* slot */ 0,
+        /* epoch */ 0,
+        HashSet::new(),
+    );
+    create_executable_environment(
+        fork_graph.clone(),
+        mock_bank,
+        &mut batch_processor.program_cache.write().unwrap(),
+    );
+    register_builtins(mock_bank, &batch_processor);
+    batch_processor
+}
+
+fn register_compute_budget_builtin(
+    mock_bank: &MockBankCallback,
+    batch_processor: &TransactionBatchProcessor<MockForkGraph>,
+) {
+    const DEPLOYMENT_SLOT: u64 = 0;
+    let compute_budget_name = "solana_compute_budget_program";
+    batch_processor.add_builtin(
+        mock_bank,
+        solana_sdk::compute_budget::id(),
+        compute_budget_name,
+        ProgramCacheEntry::new_builtin(
+            DEPLOYMENT_SLOT,
+            compute_budget_name.len(),
+            solana_compute_budget_program::Entrypoint::vm,
+        ),
+    );
+}
+
+#[test]
+fn test_processed_transactions() {
+    #[derive(Default)]
+    struct TestHandler {}
+    impl TraceHandler for TestHandler {
+        fn placeholder(&self) {
+            // Placeholder.
+        }
+    }
+
+    let rollup = MockRollup::<TestHandler>::default();
+    let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
+    let batch_processor = setup_batch_processor(rollup.bank(), &fork_graph);
+
+    let processing_environment = TransactionProcessingEnvironment {
+        rent_collector: Some(rollup.rent_collector()),
+        ..Default::default()
+    };
+    let processing_config = TransactionProcessingConfig {
+        recording_config: ExecutionRecordingConfig {
+            enable_log_recording: true,         // Record logs
+            enable_return_data_recording: true, // Record return data
+            enable_cpi_recording: false,        // Don't care about inner instructions.
+        },
+        ..Default::default()
+    };
+
+    // Set up Alice's account to have enough lamports for transfer and fees.
+    let alice = Keypair::new();
+    rollup.add_rent_exempt_account(&alice.pubkey(), &[], &system_program::id(), 100_000_000);
+
+    // Don't set up Bob's account.
+    let bob = Keypair::new();
+
+    // Set up another payer - Carol - who can attempt a transfer to Bob.
+    let carol = Keypair::new();
+    rollup.add_rent_exempt_account(&carol.pubkey(), &[], &system_program::id(), 80_000_000);
+
+    // Set up an account with an unknown owner.
+    let account_with_unknown_owner = Pubkey::new_unique();
+    rollup.add_rent_exempt_account(&account_with_unknown_owner, &[], &Pubkey::new_unique(), 0);
+
+    let sanitized_txs = [
+        // The first transaction should succeed.
+        // Alice has enough lamports for the transfer and fee.
+        Transaction::new_signed_with_payer(
+            &[system_instruction::transfer(
+                &alice.pubkey(),
+                &bob.pubkey(),
+                80_000_000,
+            )],
+            Some(&alice.pubkey()),
+            &[&alice],
+            solana_sdk::hash::Hash::default(),
+        ),
+        // The second transaction should execute but fail with an error.
+        // Carol would no longer be rent-exempt after the transfer.
+        Transaction::new_signed_with_payer(
+            &[system_instruction::transfer(
+                &carol.pubkey(),
+                &bob.pubkey(),
+                80_001_000, // Carol has 80_000_000 lamports in excess.
+            )],
+            Some(&carol.pubkey()),
+            &[&carol],
+            solana_sdk::hash::Hash::default(),
+        ),
+        // The third transaction should fail to load, therefore it should not
+        // execute.
+        // The error is caused by the unknown owner.
+        Transaction::new_signed_with_payer(
+            &[Instruction::new_with_bytes(
+                Pubkey::new_unique(),
+                &[],
+                vec![AccountMeta::new_readonly(account_with_unknown_owner, false)],
+            )],
+            Some(&alice.pubkey()), // Fee payer doesn't matter here. Alice has enough.
+            &[&alice],
+            solana_sdk::hash::Hash::default(),
+        ),
+    ]
+    .into_iter()
+    .map(SanitizedTransaction::from_transaction_for_tests)
+    .collect::<Vec<_>>();
+
+    // Invoke SVM.
+    let _results = batch_processor.load_and_execute_sanitized_transactions(
+        &rollup,
+        &sanitized_txs,
+        create_check_results(sanitized_txs.len()),
+        &processing_environment,
+        &processing_config,
+    );
+}
+
+#[test]
+fn test_proofs() {
+    #[derive(Default)]
+    struct TestHandler {}
+    impl TraceHandler for TestHandler {
+        fn placeholder(&self) {
+            // Placeholder.
+        }
+    }
+
+    let rollup = MockRollup::<TestHandler>::default();
+    let fork_graph = Arc::new(RwLock::new(MockForkGraph {}));
+    let batch_processor = setup_batch_processor(rollup.bank(), &fork_graph);
+    register_compute_budget_builtin(rollup.bank(), &batch_processor);
+
+    let processing_environment = TransactionProcessingEnvironment {
+        rent_collector: Some(rollup.rent_collector()),
+        ..Default::default()
+    };
+    let processing_config = TransactionProcessingConfig {
+        recording_config: ExecutionRecordingConfig {
+            enable_log_recording: true,         // Record logs
+            enable_return_data_recording: true, // Record return data
+            enable_cpi_recording: false,        // Don't care about inner instructions.
+        },
+        ..Default::default()
+    };
+
+    // We want a few different transactions so things like CUs and logs are
+    // different, but Alice is going to pay for all of them.
+    let alice = Keypair::new();
+    rollup.add_rent_exempt_account(
+        &alice.pubkey(),
+        &[],
+        &system_program::id(),
+        100_000_000_000_000,
+    );
+    let account_to_create = Keypair::new();
+    let account_with_no_funds = Keypair::new();
+
+    let sanitized_txs = [
+        Transaction::new_signed_with_payer(
+            &[system_instruction::create_account(
+                &alice.pubkey(),
+                &account_to_create.pubkey(),
+                20_000_000,
+                0,
+                &system_program::id(),
+            )],
+            Some(&alice.pubkey()),
+            &[&alice, &account_to_create],
+            solana_sdk::hash::Hash::default(),
+        ),
+        Transaction::new_signed_with_payer(
+            &[system_instruction::transfer(
+                &account_with_no_funds.pubkey(),
+                &Pubkey::new_unique(),
+                80_000_000,
+            )],
+            Some(&alice.pubkey()),
+            &[&alice, &account_with_no_funds],
+            solana_sdk::hash::Hash::default(),
+        ),
+        Transaction::new_signed_with_payer(
+            &[
+                solana_sdk::compute_budget::ComputeBudgetInstruction::set_compute_unit_limit(
+                    200_000_000,
+                ),
+                system_instruction::transfer(&alice.pubkey(), &Pubkey::new_unique(), 80_000_000),
+            ],
+            Some(&alice.pubkey()),
+            &[&alice],
+            solana_sdk::hash::Hash::default(),
+        ),
+    ]
+    .into_iter()
+    .map(SanitizedTransaction::from_transaction_for_tests)
+    .collect::<Vec<_>>();
+
+    // Invoke SVM.
+    let _result = batch_processor.load_and_execute_sanitized_transactions(
+        &rollup,
+        &sanitized_txs,
+        create_check_results(sanitized_txs.len()),
+        &processing_environment,
+        &processing_config,
+    );
+}


### PR DESCRIPTION
## SVM Traces (Light Clients & ZK)

This PR prototypes adding the "traces" feature to SVM.

Traces are bits of transaction processing data that can be used to craft data
structures - such as Merkle trees or Merkle-Patricia Tries - to store
information about the transactions contained in a block.

If a node was to track this information, it could produce proofs for a wide
range of transaction data, including:

- Inclusion within a block (SPV).
- Transaction result (receipt).
- Account state changes (STF).

Ideally, the roots of such data structures would be stored somewhere on-chain,
like an account or a block header. This way, a completely minified light client
could request proofs from one or more full nodes and verify those proofs against
the roots stored on the chain.

### About This Demo

This demo is a prototype implementation for SVM but also comes complete with:

- Benchmarking suite for profiling performance costs of enabling SVM traces.
- Unit test suites to demonstrate working with the primitives.
- Full light client example.

Disclaimer: I did not attempt to optimize or use more optimized existing data
structures for trees and/or hashing. The benchmarks can definitely be improved.

#### SVM Trace Hooks

I've implemented traces as callback functions within SVM's
`TransactionProcessingCallback`. They are intentionally redundant (all of them
take a reference to the transaction, for example), to ensure maximum downstream
composability. It's also just a prototype for now.

The idea behind including them as callback functions is the timing by which they
are invoked. Projects could simply consume the return type of the SVM's batch
processor post-processing, but the timing of capturing this trace may be
important. Futhermore, pre-account state would be difficult to capture without
some form of caching.

```rust
/// Hook for digesting a processed transaction during batch processing.
/// Only called when a transaction is processed. Transactions that fail
/// validation are not passed to digest.
///
/// Designed for transaction inclusion proof generation (light clients).
fn digest_processed_transaction(&self, _transaction: &impl SVMTransaction) {}

/// Hook for digesting a processed transaction receipt during batch
/// processing.
/// ...
fn digest_processed_receipt(
    &self,
    _transaction: &impl SVMTransaction,
    _receipt: &SVMTransactionReceipt,
) {
}

/// Hook for digesting a processed transactions STF trace during batch
/// processing.
/// ...
fn digest_processed_stf_trace(&self, _trace: &STFTrace<impl SVMTransaction>) {}
```

### The Trie Structure

As mentioned, I did not go through the trouble of implementing a hyper-optimized
data structure... yet. I've included a veil struct that could eventually be used
to serve this optimization - perhaps through a Merkle-Patricia Trie or something
custom - when the time comes.

For now, imagine it's a really fast dynamic Merkle tree structure.

#### Benchmarks

The benchmark suite executes 0, 10, 1,000, and 100,000 transactions against an
SVM batch processor instance with each trace enabled as well as the control (no
traces).

| Transactions | Control   | With Transaction Hashing | With Receipt Hashing | With STF Trace Hashing |
|--------------|-----------|--------------------------|----------------------|------------------------|
| 0            | 599.91 ns | 586.73 ns                | 594.99 ns            | 598.24 ns              |
| 10           | 1.4980 µs | 1.2528 µs                | 1.2775 µs            | 1.2770 µs              |
| 1,000        | 88.883 µs | 67.763 µs                | 69.120 µs            | 69.905 µs              |
| 100,000      | 11.111 ms | 9.9574 ms                | 9.9986 ms            | 9.8757 ms              |

See more at `svm/benches/trace.rs`.

#### Light Client Example

The light client example at `svm/examples/light-client` has more information in
its `lib.rs` file, however below is an overview.

On any given SVM-based chain, if full nodes enable SVM traces, they can store
these traces in Merkle trees. Then they can serve proofs to light clients.

The example demonstrates a layer 2 SVM-based blockchain - Blitz - which does
impose this Merkle tree storage requirement on its full nodes. As a result, they
can serve proofs for transaction inclusion, receipts, and STF traces.

Everything within the `blitz` module is what the example suggest a full node
would run, while everything within the `light_client` module is what a light
client would run. The interaction between the two is simply the light client
requesting (in practice over some network/RPC request) proofs to validate
transaction data.

Following a similar pattern in production, an SVM-based layer 2 or rollup could
enable light clients quite simply by enabling traces within SVM.

SVM traces also open the door to more developing more advanced tracing that
could enable ZK proofs to be generated by the SVM API.

#### Possible Roadmap for Solana L1

If we wanted to pursue development on SVM traces further for the mainnet Solana
protocol, we could fine-tune the implementation and then consider gating the SVM
feature behind a validator startup flag. We could bootstrap separate data stores
for tree structures that are not included in consensus. However, this would
leave the main piece out: the roots.

In order to have a proper light client on Solana L1, we need the tree roots (for
these data stores each node would run separate from its ledger) to exist
on-chain, in order to be validated by consensus. I propose as one idea to do so
with accounts.

We could introduce a new type of account - a Trace account - that can not be
write-locked and is updated by the runtime. However, all nodes would then have
to run the feature.

If this example is interesting to you, it's worth exploring how we could bring
this to mainnet-beta...

