### PR TITLE
svm-test-harness: add more program helpers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11094,14 +11094,24 @@ name = "solana-svm-test-harness-fixture"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "agave-precompiles",
  "bincode",
  "prost",
  "prost-build",
  "protosol",
  "solana-account",
+ "solana-address-lookup-table-interface",
+ "solana-fee-structure",
+ "solana-hash 3.1.0",
  "solana-instruction",
  "solana-instruction-error",
+ "solana-message",
  "solana-pubkey 4.0.0",
+ "solana-signature",
+ "solana-stable-layout",
+ "solana-svm-transaction",
+ "solana-transaction",
+ "solana-transaction-error",
  "thiserror 2.0.17",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11134,6 +11134,7 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-last-restart-slot",
+ "solana-loader-v4-interface",
  "solana-message",
  "solana-precompile-error",
  "solana-program-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11087,6 +11087,7 @@ dependencies = [
  "prost",
  "solana-svm-test-harness-fixture",
  "solana-svm-test-harness-instr",
+ "solana-svm-test-harness-txn",
 ]
 
 [[package]]
@@ -11147,6 +11148,43 @@ dependencies = [
  "solana-svm-transaction",
  "solana-sysvar-id",
  "solana-transaction-context",
+]
+
+[[package]]
+name = "solana-svm-test-harness-txn"
+version = "4.0.0-alpha.0"
+dependencies = [
+ "agave-feature-set",
+ "agave-logger",
+ "agave-precompiles",
+ "agave-syscalls",
+ "bincode",
+ "prost",
+ "solana-account",
+ "solana-builtins",
+ "solana-clock",
+ "solana-compute-budget",
+ "solana-compute-budget-instruction",
+ "solana-epoch-schedule",
+ "solana-fee-structure",
+ "solana-hash 3.1.0",
+ "solana-keypair",
+ "solana-message",
+ "solana-precompile-error",
+ "solana-program-runtime",
+ "solana-pubkey 4.0.0",
+ "solana-rent",
+ "solana-sdk-ids",
+ "solana-signer",
+ "solana-svm",
+ "solana-svm-callback",
+ "solana-svm-test-harness-fixture",
+ "solana-svm-test-harness-instr",
+ "solana-svm-timings",
+ "solana-svm-transaction",
+ "solana-system-interface 3.0.0",
+ "solana-sysvar-id",
+ "solana-transaction",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ members = [
     "svm-test-harness",
     "svm-test-harness/fixture",
     "svm-test-harness/instr",
+    "svm-test-harness/txn",
     "svm-timings",
     "svm-transaction",
     "svm-type-overrides",
@@ -557,6 +558,7 @@ solana-svm-measure = { path = "svm-measure", version = "=4.0.0-alpha.0", feature
 solana-svm-test-harness = { path = "svm-test-harness", version = "=4.0.0-alpha.0" }
 solana-svm-test-harness-fixture = { path = "svm-test-harness/fixture", version = "=4.0.0-alpha.0" }
 solana-svm-test-harness-instr = { path = "svm-test-harness/instr", version = "=4.0.0-alpha.0" }
+solana-svm-test-harness-txn = { path = "svm-test-harness/txn", version = "=4.0.0-alpha.0" }
 solana-svm-timings = { path = "svm-timings", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-transaction = { path = "svm-transaction", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }
 solana-svm-type-overrides = { path = "svm-type-overrides", version = "=4.0.0-alpha.0", features = ["agave-unstable-api"] }

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -4359,9 +4359,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "24ad14dd45412269e1a30f52ad8f0664f0f4f4a89ee8fe28c3b3527021ebb654"
 dependencies = [
  "bitflags 2.10.0",
  "cfg-if 1.0.4",
@@ -4400,9 +4400,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "0a9f0075ba3c21b09f8e8b2026584b1d18d49388648f2fbbf3c97ea8deced8e2"
 dependencies = [
  "cc",
  "libc",
@@ -9735,10 +9735,16 @@ name = "solana-svm-test-harness-fixture"
 version = "4.0.0-alpha.0"
 dependencies = [
  "agave-feature-set",
+ "bincode",
  "solana-account",
+ "solana-fee-structure",
+ "solana-hash 3.1.0",
  "solana-instruction",
  "solana-instruction-error",
  "solana-pubkey 4.0.0",
+ "solana-stable-layout",
+ "solana-transaction",
+ "solana-transaction-error",
  "thiserror 2.0.17",
 ]
 

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9741,6 +9741,7 @@ dependencies = [
  "solana-hash 3.1.0",
  "solana-instruction",
  "solana-instruction-error",
+ "solana-message",
  "solana-pubkey 4.0.0",
  "solana-stable-layout",
  "solana-transaction",

--- a/programs/sbf/Cargo.lock
+++ b/programs/sbf/Cargo.lock
@@ -9766,6 +9766,7 @@ dependencies = [
  "solana-instruction",
  "solana-instruction-error",
  "solana-last-restart-slot",
+ "solana-loader-v4-interface",
  "solana-message",
  "solana-precompile-error",
  "solana-program-runtime",

--- a/svm-test-harness/Cargo.toml
+++ b/svm-test-harness/Cargo.toml
@@ -15,6 +15,11 @@ name = "test_exec_instr"
 path = "bin/test_exec_instr.rs"
 required-features = ["fuzz"]
 
+[[bin]]
+name = "test_exec_txn"
+path = "bin/test_exec_txn.rs"
+required-features = ["fuzz"]
+
 [features]
 agave-unstable-api = []
 dummy-for-ci-check = ["fuzz"]
@@ -23,6 +28,7 @@ fuzz = [
     "dep:prost",
     "solana-svm-test-harness-fixture/fuzz",
     "solana-svm-test-harness-instr/fuzz",
+    "solana-svm-test-harness-txn/fuzz",
 ]
 
 [dependencies]
@@ -31,6 +37,7 @@ clap = { version = "4.5.2", features = ["derive"], optional = true }
 prost = { workspace = true, optional = true }
 solana-svm-test-harness-fixture = { workspace = true }
 solana-svm-test-harness-instr = { workspace = true }
+solana-svm-test-harness-txn = { workspace = true }
 
 [lints]
 workspace = true

--- a/svm-test-harness/bin/test_exec_txn.rs
+++ b/svm-test-harness/bin/test_exec_txn.rs
@@ -1,0 +1,52 @@
+use {
+    clap::Parser,
+    prost::Message,
+    solana_svm_test_harness::txn::{
+        fixture::proto::TxnFixture as ProtoTxnFixture, fuzz::execute_txn_proto,
+    },
+    std::path::PathBuf,
+};
+
+#[derive(Parser)]
+#[command(version, about, long_about = None)]
+struct Cli {
+    inputs: Vec<PathBuf>,
+}
+
+fn exec(input: &PathBuf) -> bool {
+    let blob = std::fs::read(input).unwrap();
+    let fixture = ProtoTxnFixture::decode(&blob[..]).unwrap();
+    let Some(context) = fixture.input else {
+        println!("No context found.");
+        return false;
+    };
+
+    let Some(expected) = fixture.output else {
+        println!("No fixture found.");
+        return false;
+    };
+    let Some(effects) = execute_txn_proto(context) else {
+        println!("FAIL: No transaction effects returned for input: {input:?}",);
+        return false;
+    };
+
+    let ok = effects == expected;
+
+    if ok {
+        println!("OK: {input:?}");
+    } else {
+        println!("FAIL: {input:?}");
+    }
+    ok
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let mut fail_cnt: i32 = 0;
+    for input in cli.inputs {
+        if !exec(&input) {
+            fail_cnt = fail_cnt.saturating_add(1);
+        }
+    }
+    std::process::exit(fail_cnt);
+}

--- a/svm-test-harness/fixture/Cargo.toml
+++ b/svm-test-harness/fixture/Cargo.toml
@@ -14,22 +14,36 @@ publish = false
 agave-unstable-api = []
 dummy-for-ci-check = ["fuzz"]
 fuzz = [
-    "dep:bincode",
+    "dep:agave-precompiles",
     "dep:prost",
     "dep:prost-build",
     "dep:protosol",
+    "dep:solana-address-lookup-table-interface",
+    "dep:solana-message",
+    "dep:solana-signature",
+    "dep:solana-svm-transaction",
     "solana-pubkey/default",
 ]
 
 [dependencies]
 agave-feature-set = { workspace = true }
-bincode = { workspace = true, optional = true }
+agave-precompiles = { workspace = true, optional = true }
+bincode = { workspace = true }
 prost = { workspace = true, optional = true }
 protosol = { workspace = true, optional = true }
 solana-account = { workspace = true }
+solana-address-lookup-table-interface = { workspace = true, optional = true, features = ["bincode", "bytemuck"] }
+solana-fee-structure = { workspace = true }
+solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
+solana-message = { workspace = true, optional = true }
 solana-pubkey = { workspace = true }
+solana-signature = { workspace = true, optional = true }
+solana-stable-layout = { workspace = true }
+solana-svm-transaction = { workspace = true, optional = true }
+solana-transaction = { workspace = true, features = ["blake3"] }
+solana-transaction-error = { workspace = true, features = ["serde"] }
 thiserror = { workspace = true }
 
 [build-dependencies]

--- a/svm-test-harness/fixture/Cargo.toml
+++ b/svm-test-harness/fixture/Cargo.toml
@@ -19,7 +19,6 @@ fuzz = [
     "dep:prost-build",
     "dep:protosol",
     "dep:solana-address-lookup-table-interface",
-    "dep:solana-message",
     "dep:solana-signature",
     "dep:solana-svm-transaction",
     "solana-pubkey/default",
@@ -37,7 +36,7 @@ solana-fee-structure = { workspace = true }
 solana-hash = { workspace = true }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
-solana-message = { workspace = true, optional = true }
+solana-message = { workspace = true }
 solana-pubkey = { workspace = true }
 solana-signature = { workspace = true, optional = true }
 solana-stable-layout = { workspace = true }

--- a/svm-test-harness/fixture/src/error.rs
+++ b/svm-test-harness/fixture/src/error.rs
@@ -12,6 +12,12 @@ pub enum FixtureError {
     #[error("Invalid public key bytes")]
     InvalidPubkeyBytes(Vec<u8>),
 
+    #[error("Invalid hash bytes")]
+    InvalidHashBytes(Vec<u8>),
+
     #[error("An account is missing for instruction account index {0}")]
     AccountMissingForInstrAccount(usize),
+
+    #[error("Invalid address lookup table")]
+    InvalidAddressLookupTable,
 }

--- a/svm-test-harness/fixture/src/lib.rs
+++ b/svm-test-harness/fixture/src/lib.rs
@@ -9,6 +9,9 @@ pub mod error;
 pub mod feature_set;
 pub mod instr_context;
 pub mod instr_effects;
+pub mod message;
+pub mod txn_context;
+pub mod txn_result;
 
 #[cfg(feature = "fuzz")]
 pub mod proto {

--- a/svm-test-harness/fixture/src/message.rs
+++ b/svm-test-harness/fixture/src/message.rs
@@ -1,0 +1,167 @@
+//! Transaction message utilities.
+
+#![cfg(feature = "fuzz")]
+
+use {
+    super::{
+        error::FixtureError,
+        proto::{
+            CompiledInstruction as ProtoCompiledInstruction,
+            MessageAddressTableLookup as ProtoMessageAddressTableLookup,
+            MessageHeader as ProtoMessageHeader, TransactionMessage as ProtoTransactionMessage,
+        },
+    },
+    solana_account::Account,
+    solana_address_lookup_table_interface::state::AddressLookupTable,
+    solana_hash::Hash,
+    solana_message::{
+        compiled_instruction::CompiledInstruction,
+        legacy,
+        v0::{self, LoadedAddresses, LoadedMessage, MessageAddressTableLookup},
+        LegacyMessage, MessageHeader, SanitizedMessage,
+    },
+    solana_pubkey::Pubkey,
+    std::{cmp::max, collections::HashSet},
+};
+
+impl From<&ProtoMessageHeader> for MessageHeader {
+    fn from(value: &ProtoMessageHeader) -> Self {
+        MessageHeader {
+            num_required_signatures: max(1, value.num_required_signatures as u8),
+            num_readonly_signed_accounts: value.num_readonly_signed_accounts as u8,
+            num_readonly_unsigned_accounts: value.num_readonly_unsigned_accounts as u8,
+        }
+    }
+}
+
+impl From<&ProtoCompiledInstruction> for CompiledInstruction {
+    fn from(value: &ProtoCompiledInstruction) -> Self {
+        CompiledInstruction {
+            program_id_index: value.program_id_index as u8,
+            accounts: value.accounts.iter().map(|idx| *idx as u8).collect(),
+            data: value.data.clone(),
+        }
+    }
+}
+
+impl From<&ProtoMessageAddressTableLookup> for MessageAddressTableLookup {
+    fn from(value: &ProtoMessageAddressTableLookup) -> Self {
+        MessageAddressTableLookup {
+            account_key: Pubkey::new_from_array(value.account_key.clone().try_into().unwrap()),
+            writable_indexes: value
+                .writable_indexes
+                .iter()
+                .map(|idx| *idx as u8)
+                .collect(),
+            readonly_indexes: value
+                .readonly_indexes
+                .iter()
+                .map(|idx| *idx as u8)
+                .collect(),
+        }
+    }
+}
+
+fn resolve_address_table_lookups(
+    lookups: &[MessageAddressTableLookup],
+    accounts: &[(Pubkey, Account)],
+) -> Result<LoadedAddresses, FixtureError> {
+    let mut writable = Vec::new();
+    let mut readonly = Vec::new();
+
+    for lookup in lookups {
+        let alt_account = accounts
+            .iter()
+            .find(|(pubkey, _)| *pubkey == lookup.account_key)
+            .map(|(_, account)| account)
+            .ok_or(FixtureError::InvalidAddressLookupTable)?;
+
+        let alt = AddressLookupTable::deserialize(&alt_account.data)
+            .map_err(|_| FixtureError::InvalidAddressLookupTable)?;
+
+        for &idx in &lookup.writable_indexes {
+            writable.push(
+                *alt.addresses
+                    .get(idx as usize)
+                    .ok_or(FixtureError::InvalidAddressLookupTable)?,
+            );
+        }
+        for &idx in &lookup.readonly_indexes {
+            readonly.push(
+                *alt.addresses
+                    .get(idx as usize)
+                    .ok_or(FixtureError::InvalidAddressLookupTable)?,
+            );
+        }
+    }
+
+    Ok(LoadedAddresses { writable, readonly })
+}
+
+pub fn build_sanitized_message(
+    value: &ProtoTransactionMessage,
+    accounts: &[(Pubkey, Account)],
+) -> Result<SanitizedMessage, FixtureError> {
+    let header = if let Some(ref value_header) = value.header {
+        MessageHeader::from(value_header)
+    } else {
+        MessageHeader {
+            num_required_signatures: 1,
+            num_readonly_signed_accounts: 0,
+            num_readonly_unsigned_accounts: 0,
+        }
+    };
+
+    let account_keys = value
+        .account_keys
+        .iter()
+        .map(|key| Pubkey::new_from_array(key.clone().try_into().unwrap()))
+        .collect::<Vec<Pubkey>>();
+
+    let recent_blockhash = if value.recent_blockhash.is_empty() {
+        Hash::new_from_array([0u8; 32])
+    } else {
+        Hash::new_from_array(value.recent_blockhash.clone().try_into().unwrap())
+    };
+
+    let instructions = value
+        .instructions
+        .iter()
+        .map(CompiledInstruction::from)
+        .collect::<Vec<CompiledInstruction>>();
+
+    if value.is_legacy {
+        let message = legacy::Message {
+            header,
+            account_keys,
+            recent_blockhash,
+            instructions,
+        };
+        Ok(SanitizedMessage::Legacy(LegacyMessage::new(
+            message,
+            &HashSet::new(),
+        )))
+    } else {
+        let address_table_lookups = value
+            .address_table_lookups
+            .iter()
+            .map(MessageAddressTableLookup::from)
+            .collect::<Vec<MessageAddressTableLookup>>();
+
+        let loaded_addresses = resolve_address_table_lookups(&address_table_lookups, accounts)?;
+
+        let message = v0::Message {
+            header,
+            account_keys,
+            recent_blockhash,
+            instructions,
+            address_table_lookups,
+        };
+
+        Ok(SanitizedMessage::V0(LoadedMessage::new(
+            message,
+            loaded_addresses,
+            &HashSet::new(),
+        )))
+    }
+}

--- a/svm-test-harness/fixture/src/txn_context.rs
+++ b/svm-test-harness/fixture/src/txn_context.rs
@@ -1,0 +1,132 @@
+//! Transaction context (input).
+
+use {
+    agave_feature_set::FeatureSet,
+    solana_account::Account,
+    solana_hash::Hash,
+    solana_pubkey::Pubkey,
+    solana_transaction::{sanitized::SanitizedTransaction, Transaction},
+};
+
+/// Transaction context fixture.
+pub struct TxnContext {
+    pub feature_set: FeatureSet,
+    pub blockhash_queue: Vec<Hash>,
+    pub slot: u64,
+    pub accounts: Vec<(Pubkey, Account)>,
+    pub transaction: SanitizedTransaction,
+}
+
+impl TxnContext {
+    pub fn new(
+        feature_set: FeatureSet,
+        blockhash_queue: Vec<Hash>,
+        slot: u64,
+        accounts: Vec<(Pubkey, Account)>,
+        transaction: Transaction,
+    ) -> Self {
+        let transaction = SanitizedTransaction::from_transaction_for_tests(transaction);
+        Self {
+            feature_set,
+            blockhash_queue,
+            slot,
+            accounts,
+            transaction,
+        }
+    }
+}
+
+#[cfg(feature = "fuzz")]
+use {
+    super::{
+        error::FixtureError, message::build_sanitized_message, proto::TxnContext as ProtoTxnContext,
+    },
+    solana_signature::Signature,
+};
+
+#[cfg(feature = "fuzz")]
+impl TryFrom<ProtoTxnContext> for TxnContext {
+    type Error = FixtureError;
+
+    fn try_from(value: ProtoTxnContext) -> Result<Self, Self::Error> {
+        let feature_set: FeatureSet = value
+            .epoch_ctx
+            .as_ref()
+            .and_then(|epoch_ctx| epoch_ctx.features.as_ref())
+            .map(|fs| fs.into())
+            .unwrap_or_default();
+
+        let blockhash_queue: Vec<Hash> = if value.blockhash_queue.is_empty() {
+            vec![Hash::default()]
+        } else {
+            value
+                .blockhash_queue
+                .into_iter()
+                .map(|hash_bytes| {
+                    let hash_array: [u8; 32] = hash_bytes
+                        .try_into()
+                        .map_err(FixtureError::InvalidHashBytes)?;
+                    Ok(Hash::new_from_array(hash_array))
+                })
+                .collect::<Result<Vec<_>, FixtureError>>()?
+        };
+
+        let slot = value
+            .slot_ctx
+            .as_ref()
+            .map(|slot_ctx| slot_ctx.slot)
+            .unwrap_or_default();
+
+        let accounts: Vec<(Pubkey, Account)> = value
+            .account_shared_data
+            .into_iter()
+            .map(|acct_state| acct_state.try_into())
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let proto_tx = value.tx.ok_or(FixtureError::InvalidFixtureInput)?;
+        let proto_message = proto_tx.message.ok_or(FixtureError::InvalidFixtureInput)?;
+
+        let message = build_sanitized_message(&proto_message, &accounts)?;
+        let message_hash: Hash = if proto_tx.message_hash.is_empty() {
+            Hash::default()
+        } else {
+            let hash_array: [u8; 32] = proto_tx
+                .message_hash
+                .try_into()
+                .map_err(FixtureError::InvalidHashBytes)?;
+            Hash::new_from_array(hash_array)
+        };
+
+        let mut signatures: Vec<Signature> = proto_tx
+            .signatures
+            .iter()
+            .map(|sig_bytes| {
+                let sig_array: [u8; 64] = sig_bytes
+                    .clone()
+                    .try_into()
+                    .map_err(|_| FixtureError::InvalidFixtureInput)?;
+                Ok(Signature::from(sig_array))
+            })
+            .collect::<Result<Vec<_>, FixtureError>>()?;
+
+        if signatures.is_empty() {
+            signatures.push(Signature::default());
+        }
+
+        let transaction = SanitizedTransaction::try_new_from_fields(
+            message,
+            message_hash,
+            /* is_simple_vote_tx */ false,
+            signatures,
+        )
+        .map_err(|_| FixtureError::InvalidFixtureInput)?;
+
+        Ok(Self {
+            feature_set,
+            blockhash_queue,
+            slot,
+            accounts,
+            transaction,
+        })
+    }
+}

--- a/svm-test-harness/fixture/src/txn_result.rs
+++ b/svm-test-harness/fixture/src/txn_result.rs
@@ -1,0 +1,136 @@
+//! Transaction result (output).
+
+use {
+    solana_account::Account, solana_fee_structure::FeeDetails, solana_pubkey::Pubkey,
+    solana_transaction_error::TransactionResult,
+};
+
+/// Transaction execution result.
+#[derive(Clone, Debug, PartialEq)]
+pub struct TxnResult {
+    pub status: TransactionResult<()>,
+    pub resulting_accounts: Vec<(Pubkey, Account)>,
+    pub return_data: Vec<u8>,
+    pub executed_units: u64,
+    pub fee_details: FeeDetails,
+    pub loaded_accounts_data_size: u64,
+}
+
+#[cfg(feature = "fuzz")]
+use {
+    super::proto::{
+        FeeDetails as ProtoFeeDetails, ResultingState as ProtoResultingState,
+        TxnResult as ProtoTxnResult,
+    },
+    agave_precompiles::get_precompile,
+    solana_instruction_error::InstructionError,
+    solana_svm_transaction::svm_message::SVMMessage,
+    solana_transaction_error::TransactionError,
+};
+
+#[cfg(feature = "fuzz")]
+fn transaction_error_to_err_nums(error: &TransactionError) -> (u32, u32, u32, u32) {
+    let (instr_err_no, custom_err_no, instr_err_idx) = match error.clone() {
+        TransactionError::InstructionError(idx, instr_err) => {
+            let instr_err_no = {
+                let serialized = bincode::serialize(&instr_err).unwrap_or(vec![0, 0, 0, 0]);
+                u32::from_le_bytes(serialized[0..4].try_into().unwrap()).saturating_add(1)
+            };
+            let custom_err_no = match instr_err {
+                InstructionError::Custom(code) => code,
+                _ => 0,
+            };
+            (instr_err_no, custom_err_no, idx)
+        }
+        _ => (0, 0, 0),
+    };
+
+    let txn_err_no = {
+        let serialized = bincode::serialize(error).unwrap_or(vec![0, 0, 0, 0]);
+        u32::from_le_bytes(serialized[0..4].try_into().unwrap()).saturating_add(1)
+    };
+
+    (
+        txn_err_no,
+        instr_err_no,
+        custom_err_no,
+        instr_err_idx.into(),
+    )
+}
+
+/// Convert a `TxnResult` to a protobuf `TxnResult`, filtering accounts to only
+/// those marked writable in the message.
+#[cfg(feature = "fuzz")]
+pub fn txn_result_to_proto(result: TxnResult, message: &impl SVMMessage) -> ProtoTxnResult {
+    let acct_states: Vec<_> = result
+        .resulting_accounts
+        .into_iter()
+        .enumerate()
+        .filter(|&(i, _)| message.is_writable(i))
+        .map(|(_, acct)| acct.into())
+        .collect();
+
+    let (
+        executed,
+        sanitization_error,
+        is_ok,
+        status,
+        instruction_error,
+        instruction_error_index,
+        custom_error,
+    ) = match &result.status {
+        Ok(()) => (true, false, true, 0, 0, 0, 0),
+        Err(err) => {
+            let (status, instr_err, custom_err, instr_err_idx) = transaction_error_to_err_nums(err);
+            // Set custom err to 0 if the failing instruction is a precompile.
+            let custom_err = message
+                .instructions_iter()
+                .nth(instr_err_idx as usize)
+                .and_then(|instr| {
+                    message
+                        .account_keys()
+                        .get(usize::from(instr.program_id_index))
+                        .map(|program_id| {
+                            if get_precompile(program_id, |_| true).is_some() {
+                                0
+                            } else {
+                                custom_err
+                            }
+                        })
+                })
+                .unwrap_or(custom_err);
+            (
+                true,
+                false,
+                false,
+                status,
+                instr_err,
+                instr_err_idx,
+                custom_err,
+            )
+        }
+    };
+
+    ProtoTxnResult {
+        executed,
+        sanitization_error,
+        resulting_state: Some(ProtoResultingState {
+            acct_states,
+            rent_debits: vec![],
+            transaction_rent: 0,
+        }),
+        rent: 0,
+        is_ok,
+        status,
+        instruction_error,
+        instruction_error_index,
+        custom_error,
+        return_data: result.return_data,
+        executed_units: result.executed_units,
+        fee_details: Some(ProtoFeeDetails {
+            transaction_fee: result.fee_details.transaction_fee(),
+            prioritization_fee: result.fee_details.prioritization_fee(),
+        }),
+        loaded_accounts_data_size: result.loaded_accounts_data_size,
+    }
+}

--- a/svm-test-harness/fixture/src/txn_result.rs
+++ b/svm-test-harness/fixture/src/txn_result.rs
@@ -1,7 +1,8 @@
 //! Transaction result (output).
 
 use {
-    solana_account::Account, solana_fee_structure::FeeDetails, solana_pubkey::Pubkey,
+    solana_account::Account, solana_fee_structure::FeeDetails,
+    solana_message::inner_instruction::InnerInstructionsList, solana_pubkey::Pubkey,
     solana_transaction_error::TransactionResult,
 };
 
@@ -14,6 +15,8 @@ pub struct TxnResult {
     pub executed_units: u64,
     pub fee_details: FeeDetails,
     pub loaded_accounts_data_size: u64,
+    pub inner_instructions: Option<InnerInstructionsList>,
+    pub log_messages: Option<Vec<String>>,
 }
 
 #[cfg(feature = "fuzz")]

--- a/svm-test-harness/instr/Cargo.toml
+++ b/svm-test-harness/instr/Cargo.toml
@@ -34,6 +34,7 @@ solana-epoch-schedule = { workspace = true, features = ["sysvar"] }
 solana-instruction = { workspace = true }
 solana-instruction-error = { workspace = true, features = ["serde"] }
 solana-last-restart-slot = { workspace = true, features = ["sysvar"] }
+solana-loader-v4-interface = { workspace = true }
 solana-message = { workspace = true }
 solana-precompile-error = { workspace = true }
 solana-program-runtime = { workspace = true }

--- a/svm-test-harness/instr/src/keyed_account.rs
+++ b/svm-test-harness/instr/src/keyed_account.rs
@@ -1,7 +1,11 @@
 //! Keyed account helpers.
 
 use {
-    solana_account::Account, solana_builtins::BUILTINS, solana_pubkey::Pubkey, solana_rent::Rent,
+    solana_account::Account,
+    solana_builtins::BUILTINS,
+    solana_loader_v4_interface::state::{LoaderV4State, LoaderV4Status},
+    solana_pubkey::Pubkey,
+    solana_rent::Rent,
 };
 
 fn create_keyed_account_for_builtin_program(program_id: &Pubkey, name: &str) -> (Pubkey, Account) {
@@ -19,4 +23,42 @@ fn create_keyed_account_for_builtin_program(program_id: &Pubkey, name: &str) -> 
 
 pub fn keyed_account_for_system_program() -> (Pubkey, Account) {
     create_keyed_account_for_builtin_program(&BUILTINS[0].program_id, BUILTINS[0].name)
+}
+
+pub fn keyed_account_for_compute_budget_program() -> (Pubkey, Account) {
+    create_keyed_account_for_builtin_program(&BUILTINS[5].program_id, BUILTINS[5].name)
+}
+
+pub fn keyed_account_for_loader_v4_program() -> (Pubkey, Account) {
+    create_keyed_account_for_builtin_program(&BUILTINS[7].program_id, BUILTINS[7].name)
+}
+
+pub fn create_program_account_loader_v4(
+    slot: u64,
+    authority_address_or_next_version: Pubkey,
+    status: LoaderV4Status,
+    elf: &[u8],
+) -> Account {
+    let data = unsafe {
+        let elf_offset = LoaderV4State::program_data_offset();
+        let data_len = elf_offset.saturating_add(elf.len());
+        let mut data = vec![0u8; data_len];
+        *std::mem::transmute::<&mut [u8; LoaderV4State::program_data_offset()], &mut LoaderV4State>(
+            (&mut data[0..elf_offset]).try_into().unwrap(),
+        ) = LoaderV4State {
+            slot,
+            authority_address_or_next_version,
+            status,
+        };
+        data[elf_offset..].copy_from_slice(elf);
+        data
+    };
+    let lamports = Rent::default().minimum_balance(data.len());
+    Account {
+        lamports,
+        data,
+        owner: solana_sdk_ids::loader_v4::id(),
+        executable: true,
+        ..Default::default()
+    }
 }

--- a/svm-test-harness/src/lib.rs
+++ b/svm-test-harness/src/lib.rs
@@ -1,3 +1,6 @@
 //! Solana SVM test harness.
 
-pub use {solana_svm_test_harness_fixture as fixture, solana_svm_test_harness_instr as instr};
+pub use {
+    solana_svm_test_harness_fixture as fixture, solana_svm_test_harness_instr as instr,
+    solana_svm_test_harness_txn as txn,
+};

--- a/svm-test-harness/txn/Cargo.toml
+++ b/svm-test-harness/txn/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "solana-svm-test-harness-txn"
+description = "Solana SVM test harness for transaction execution."
+documentation = "https://docs.rs/solana-svm-test-harness-txn"
+version = { workspace = true }
+authors = { workspace = true }
+repository = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+edition = { workspace = true }
+publish = false
+
+[features]
+fuzz = [
+    "dep:agave-logger",
+    "dep:prost",
+    "solana-pubkey/default",
+    "solana-svm-test-harness-fixture/fuzz",
+]
+
+[dependencies]
+agave-logger = { workspace = true, optional = true }
+prost = { workspace = true, optional = true }
+agave-feature-set = { workspace = true }
+agave-precompiles = { workspace = true }
+agave-syscalls = { workspace = true }
+solana-account = { workspace = true }
+solana-builtins = { workspace = true }
+solana-clock = { workspace = true }
+solana-compute-budget = { workspace = true }
+solana-compute-budget-instruction = { workspace = true }
+solana-fee-structure = { workspace = true }
+solana-precompile-error = { workspace = true }
+solana-program-runtime = { workspace = true }
+solana-pubkey = { workspace = true }
+solana-sdk-ids = { workspace = true }
+solana-svm = { workspace = true }
+solana-svm-callback = { workspace = true }
+solana-svm-test-harness-fixture = { workspace = true }
+solana-svm-test-harness-instr = { workspace = true }
+solana-svm-timings = { workspace = true }
+solana-svm-transaction = { workspace = true }
+
+[dev-dependencies]
+bincode = { workspace = true }
+solana-epoch-schedule = { workspace = true }
+solana-hash = { workspace = true }
+solana-keypair = { workspace = true }
+solana-message = { workspace = true }
+solana-rent = { workspace = true }
+solana-sdk-ids = { workspace = true }
+solana-signer = { workspace = true }
+solana-system-interface = { workspace = true }
+solana-sysvar-id = { workspace = true }
+solana-transaction = { workspace = true }
+
+[lints]
+workspace = true

--- a/svm-test-harness/txn/src/fuzz.rs
+++ b/svm-test-harness/txn/src/fuzz.rs
@@ -1,0 +1,87 @@
+//! FFI bindings for transaction execution fuzzing.
+
+#![allow(clippy::missing_safety_doc)]
+
+use {
+    crate::{
+        execute_txn,
+        fixture::{
+            proto::{TxnContext as ProtoTxnContext, TxnResult as ProtoTxnResult},
+            txn_context::TxnContext,
+            txn_result::txn_result_to_proto,
+        },
+    },
+    agave_feature_set::{increase_cpi_account_info_limit, raise_cpi_nesting_limit_to_8},
+    prost::Message,
+    solana_compute_budget::compute_budget::ComputeBudget,
+    std::{env, ffi::c_int},
+};
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sol_compat_init(_log_level: i32) {
+    unsafe {
+        env::set_var("SOLANA_RAYON_THREADS", "1");
+        env::set_var("RAYON_NUM_THREADS", "1");
+    }
+    if env::var("ENABLE_SOLANA_LOGGER").is_ok() {
+        agave_logger::setup();
+    }
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sol_compat_fini() {}
+
+/// Execute a transaction from protobuf input and return protobuf output.
+pub fn execute_txn_proto(input: ProtoTxnContext) -> Option<ProtoTxnResult> {
+    let context = TxnContext::try_from(input).ok()?;
+
+    // Clone the transaction before passing context to execute_txn,
+    // since we need it for txn_result_to_proto.
+    let transaction = context.transaction.clone();
+
+    // Set up compute budget based on active features.
+    let simd_0268_active = context
+        .feature_set
+        .is_active(&raise_cpi_nesting_limit_to_8::id());
+    let simd_0339_active = context
+        .feature_set
+        .is_active(&increase_cpi_account_info_limit::id());
+    let compute_budget = ComputeBudget::new_with_defaults(simd_0268_active, simd_0339_active);
+
+    let result = execute_txn(context, &compute_budget, None)?;
+
+    Some(txn_result_to_proto(result, &transaction))
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn sol_compat_txn_execute_v1(
+    out_ptr: *mut u8,
+    out_psz: *mut u64,
+    in_ptr: *mut u8,
+    in_sz: u64,
+) -> c_int {
+    if in_ptr.is_null() || in_sz == 0 {
+        return 0;
+    }
+
+    let in_slice = unsafe { std::slice::from_raw_parts(in_ptr, in_sz as usize) };
+    let Ok(input) = ProtoTxnContext::decode(in_slice) else {
+        return 0;
+    };
+
+    let Some(output) = execute_txn_proto(input) else {
+        return 0;
+    };
+
+    let out_slice = unsafe { std::slice::from_raw_parts_mut(out_ptr, (*out_psz) as usize) };
+    let out_vec = output.encode_to_vec();
+    if out_vec.len() > out_slice.len() {
+        return 0;
+    }
+
+    out_slice[..out_vec.len()].copy_from_slice(&out_vec);
+    unsafe {
+        *out_psz = out_vec.len() as u64;
+    }
+    1
+}

--- a/svm-test-harness/txn/src/harness.rs
+++ b/svm-test-harness/txn/src/harness.rs
@@ -1,0 +1,457 @@
+//! Transaction harness.
+
+use {
+    agave_feature_set::{raise_cpi_nesting_limit_to_8, FeatureSet},
+    agave_precompiles::{get_precompile, is_precompile},
+    agave_syscalls::create_program_runtime_environment_v1,
+    solana_account::{Account, AccountSharedData},
+    solana_builtins::BUILTINS,
+    solana_clock::Slot,
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_compute_budget_instruction::instructions_processor::process_compute_budget_instructions,
+    solana_fee_structure::FeeDetails,
+    solana_precompile_error::PrecompileError,
+    solana_program_runtime::loaded_programs::{
+        BlockRelation, ForkGraph, ProgramCache, ProgramCacheEntry, ProgramRuntimeEnvironments,
+    },
+    solana_pubkey::Pubkey,
+    solana_sdk_ids::native_loader,
+    solana_svm::{
+        account_loader::CheckedTransactionDetails,
+        program_loader::load_program_with_pubkey,
+        transaction_processing_result::ProcessedTransaction,
+        transaction_processor::{
+            ExecutionRecordingConfig, TransactionBatchProcessor, TransactionProcessingConfig,
+            TransactionProcessingEnvironment,
+        },
+    },
+    solana_svm_callback::{InvokeContextCallback, TransactionProcessingCallback},
+    solana_svm_test_harness_fixture::{txn_context::TxnContext, txn_result::TxnResult},
+    solana_svm_timings::ExecuteTimings,
+    solana_svm_transaction::svm_message::SVMStaticMessage,
+    std::{
+        collections::HashSet,
+        sync::{Arc, RwLock},
+    },
+};
+
+const LAMPORTS_PER_SIGNATURE: u64 = 5000;
+const SLOTS_PER_EPOCH: u64 = 432_000;
+
+struct MockForkGraph;
+
+impl ForkGraph for MockForkGraph {
+    fn relationship(&self, _a: Slot, _b: Slot) -> BlockRelation {
+        BlockRelation::Unknown
+    }
+}
+
+struct TxnContextCallback<'a>(&'a TxnContext);
+
+impl InvokeContextCallback for TxnContextCallback<'_> {
+    fn is_precompile(&self, program_id: &Pubkey) -> bool {
+        is_precompile(program_id, |feature_id: &Pubkey| {
+            self.0.feature_set.is_active(feature_id)
+        })
+    }
+
+    fn process_precompile(
+        &self,
+        program_id: &Pubkey,
+        data: &[u8],
+        instruction_datas: Vec<&[u8]>,
+    ) -> std::result::Result<(), PrecompileError> {
+        if let Some(precompile) = get_precompile(program_id, |feature_id: &Pubkey| {
+            self.0.feature_set.is_active(feature_id)
+        }) {
+            precompile.verify(data, &instruction_datas, &self.0.feature_set)
+        } else {
+            Err(PrecompileError::InvalidPublicKey)
+        }
+    }
+}
+
+impl TransactionProcessingCallback for TxnContextCallback<'_> {
+    fn get_account_shared_data(&self, pubkey: &Pubkey) -> Option<(AccountSharedData, Slot)> {
+        self.0
+            .accounts
+            .iter()
+            .find(|(key, _)| key == pubkey)
+            .filter(|(_, account)| account.lamports > 0)
+            .map(|(_, account)| (AccountSharedData::from(account.clone()), self.0.slot))
+    }
+}
+
+fn is_loader_owned(owner: &Pubkey) -> bool {
+    solana_sdk_ids::loader_v4::check_id(owner)
+        || solana_sdk_ids::bpf_loader_deprecated::check_id(owner)
+        || solana_sdk_ids::bpf_loader::check_id(owner)
+        || solana_sdk_ids::bpf_loader_upgradeable::check_id(owner)
+}
+
+fn load_programs_from_accounts(
+    program_cache: &mut ProgramCache<MockForkGraph>,
+    environments: &ProgramRuntimeEnvironments,
+    callback: &TxnContextCallback<'_>,
+) -> HashSet<Pubkey> {
+    let mut builtin_ids = HashSet::new();
+    let slot = callback.0.slot;
+
+    for (pubkey, account) in &callback.0.accounts {
+        // Track builtins.
+        if native_loader::check_id(&account.owner) && account.executable {
+            if let Some(builtin) = BUILTINS.iter().find(|b| b.program_id == *pubkey) {
+                builtin_ids.insert(*pubkey);
+                let entry = Arc::new(ProgramCacheEntry::new_builtin(
+                    0,
+                    account.data.len(),
+                    builtin.entrypoint,
+                ));
+                program_cache.assign_program(
+                    &ProgramRuntimeEnvironments::default(),
+                    *pubkey,
+                    0,
+                    entry,
+                );
+            }
+            continue;
+        }
+
+        // Load programs owned by one of the BPF loaders.
+        if is_loader_owned(&account.owner) {
+            if let Some((loaded_program, _last_modification_slot)) = load_program_with_pubkey(
+                callback,
+                environments,
+                pubkey,
+                slot,
+                &mut ExecuteTimings::default(),
+                false, // reload
+            ) {
+                program_cache.assign_program(environments, *pubkey, slot, loaded_program);
+            }
+        }
+    }
+
+    builtin_ids
+}
+
+fn setup_batch_processor(
+    callback: &TxnContextCallback<'_>,
+    compute_budget: &ComputeBudget,
+    feature_set: &FeatureSet,
+    fork_graph: &Arc<RwLock<MockForkGraph>>,
+    epoch: u64,
+) -> TransactionBatchProcessor<MockForkGraph> {
+    let slot = callback.0.slot;
+
+    let environments = ProgramRuntimeEnvironments {
+        program_runtime_v1: Arc::new(
+            create_program_runtime_environment_v1(
+                &feature_set.runtime_features(),
+                &compute_budget.to_budget(),
+                false, /* deployment */
+                false, /* debugging_features */
+            )
+            .unwrap(),
+        ),
+        ..ProgramRuntimeEnvironments::default()
+    };
+
+    let mut batch_processor = TransactionBatchProcessor::new_uninitialized(slot, epoch);
+
+    batch_processor.environments.program_runtime_v1 = Arc::clone(&environments.program_runtime_v1);
+    batch_processor.environments.program_runtime_v2 = Arc::clone(&environments.program_runtime_v2);
+
+    let mut program_cache = batch_processor.global_program_cache.write().unwrap();
+    program_cache.set_fork_graph(Arc::downgrade(fork_graph));
+
+    // Load programs from accounts directly into global cache.
+    let builtin_ids = load_programs_from_accounts(&mut program_cache, &environments, callback);
+    drop(program_cache);
+
+    // Set builtin program IDs.
+    batch_processor
+        .builtin_program_ids
+        .get_mut()
+        .unwrap()
+        .extend(builtin_ids);
+
+    batch_processor
+}
+
+/// Execute a single transaction against the Solana VM.
+pub fn execute_txn(
+    input: TxnContext,
+    compute_budget: &ComputeBudget,
+    recording_config: Option<ExecutionRecordingConfig>,
+) -> Option<TxnResult> {
+    let blockhash = input.blockhash_queue.first().cloned().unwrap_or_default();
+    let feature_set = input.feature_set.runtime_features();
+    let slot = input.slot;
+    let epoch = slot / SLOTS_PER_EPOCH;
+
+    let simd_0268_active = input
+        .feature_set
+        .is_active(&raise_cpi_nesting_limit_to_8::id());
+
+    let compute_budget_limits = process_compute_budget_instructions(
+        SVMStaticMessage::program_instructions_iter(&input.transaction),
+        &input.feature_set,
+    )
+    .ok()?;
+
+    let callback = TxnContextCallback(&input);
+    let fork_graph = Arc::new(RwLock::new(MockForkGraph));
+    let batch_processor = setup_batch_processor(
+        &callback,
+        compute_budget,
+        &input.feature_set,
+        &fork_graph,
+        epoch,
+    );
+
+    let check_result = Ok(CheckedTransactionDetails::new(
+        None,
+        compute_budget_limits.get_compute_budget_and_limits(
+            compute_budget_limits.loaded_accounts_bytes,
+            FeeDetails::default(),
+            simd_0268_active,
+        ),
+    ));
+
+    let environments = batch_processor.get_environments_for_epoch(epoch);
+    let processing_environment = TransactionProcessingEnvironment {
+        blockhash,
+        feature_set,
+        blockhash_lamports_per_signature: LAMPORTS_PER_SIGNATURE,
+        program_runtime_environments_for_execution: environments.clone(),
+        program_runtime_environments_for_deployment: environments,
+        ..Default::default()
+    };
+
+    let recording_config = recording_config.unwrap_or(ExecutionRecordingConfig {
+        enable_cpi_recording: false,
+        enable_log_recording: true,
+        enable_return_data_recording: true,
+        enable_transaction_balance_recording: false,
+    });
+
+    let processing_config = TransactionProcessingConfig {
+        account_overrides: None,
+        check_program_deployment_slot: false,
+        log_messages_bytes_limit: None,
+        limit_to_load_programs: true,
+        recording_config,
+        drop_on_failure: false,
+        all_or_nothing: false,
+    };
+
+    let transactions = vec![input.transaction.clone()];
+    let check_results = vec![check_result];
+
+    let output = batch_processor.load_and_execute_sanitized_transactions(
+        &callback,
+        &transactions,
+        check_results,
+        &processing_environment,
+        &processing_config,
+    );
+
+    match &output.processing_results[0] {
+        Ok(txn) => {
+            let resulting_accounts = match txn {
+                ProcessedTransaction::Executed(executed_tx) => executed_tx
+                    .loaded_transaction
+                    .accounts
+                    .iter()
+                    .map(|(pubkey, account)| (*pubkey, Account::from(account.clone())))
+                    .collect(),
+                ProcessedTransaction::FeesOnly(fees_only_tx) => fees_only_tx
+                    .rollback_accounts
+                    .iter()
+                    .map(|(pubkey, account)| (*pubkey, Account::from(account.clone())))
+                    .collect(),
+            };
+
+            let return_data = match txn {
+                ProcessedTransaction::Executed(executed_tx) => executed_tx
+                    .execution_details
+                    .return_data
+                    .as_ref()
+                    .map(|info| info.data.clone())
+                    .unwrap_or_default(),
+                ProcessedTransaction::FeesOnly(_) => vec![],
+            };
+
+            let inner_instructions = match txn {
+                ProcessedTransaction::Executed(executed_tx) => {
+                    executed_tx.execution_details.inner_instructions.clone()
+                }
+                ProcessedTransaction::FeesOnly(_) => None,
+            };
+
+            let log_messages = match txn {
+                ProcessedTransaction::Executed(executed_tx) => {
+                    executed_tx.execution_details.log_messages.clone()
+                }
+                ProcessedTransaction::FeesOnly(_) => None,
+            };
+
+            Some(TxnResult {
+                status: txn.status(),
+                resulting_accounts,
+                return_data,
+                executed_units: txn.executed_units(),
+                fee_details: txn.fee_details(),
+                loaded_accounts_data_size: txn.loaded_accounts_data_size() as u64,
+                inner_instructions,
+                log_messages,
+            })
+        }
+        Err(err) => Some(TxnResult {
+            status: Err(err.clone()),
+            resulting_accounts: vec![],
+            return_data: vec![],
+            executed_units: 0,
+            fee_details: FeeDetails::default(),
+            loaded_accounts_data_size: 0,
+            inner_instructions: None,
+            log_messages: None,
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use {
+        super::*, agave_feature_set::FeatureSet, solana_hash::Hash, solana_keypair::Keypair,
+        solana_message::Message, solana_signer::Signer,
+        solana_svm_test_harness_fixture::txn_context::TxnContext,
+        solana_svm_test_harness_instr::keyed_account::keyed_account_for_system_program,
+        solana_system_interface::instruction as system_instruction, solana_sysvar_id::SysvarId,
+        solana_transaction::Transaction,
+    };
+
+    fn sysvar_account(data: Vec<u8>) -> Account {
+        Account {
+            lamports: 1,
+            data,
+            owner: solana_sysvar_id::id(),
+            executable: false,
+            rent_epoch: u64::MAX,
+        }
+    }
+
+    fn create_sysvar_accounts() -> Vec<(Pubkey, Account)> {
+        vec![
+            (
+                solana_clock::Clock::id(),
+                sysvar_account(bincode::serialize(&solana_clock::Clock::default()).unwrap()),
+            ),
+            (
+                solana_rent::Rent::id(),
+                sysvar_account(bincode::serialize(&solana_rent::Rent::default()).unwrap()),
+            ),
+            (
+                solana_epoch_schedule::EpochSchedule::id(),
+                sysvar_account(
+                    bincode::serialize(&solana_epoch_schedule::EpochSchedule::default()).unwrap(),
+                ),
+            ),
+            keyed_account_for_system_program(),
+        ]
+    }
+
+    fn user_account(lamports: u64) -> Account {
+        Account {
+            lamports,
+            data: vec![],
+            owner: solana_sdk_ids::system_program::id(),
+            executable: false,
+            rent_epoch: u64::MAX,
+        }
+    }
+
+    #[test]
+    fn test_system_transfer() {
+        let fee_payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let blockhash = Hash::new_unique();
+        let slot = 10u64;
+        let feature_set = FeatureSet::default();
+
+        let mut accounts = vec![
+            (fee_payer.pubkey(), user_account(10_000_000)),
+            (recipient, user_account(0)),
+        ];
+        accounts.extend(create_sysvar_accounts());
+
+        let transfer_amount = 1_000_000;
+        let instruction =
+            system_instruction::transfer(&fee_payer.pubkey(), &recipient, transfer_amount);
+        let message = Message::new(&[instruction], Some(&fee_payer.pubkey()));
+        let transaction = Transaction::new(&[&fee_payer], message, blockhash);
+
+        let context = TxnContext::new(
+            feature_set.clone(),
+            vec![blockhash],
+            slot,
+            accounts,
+            transaction,
+        );
+
+        // Set up the Compute Budget.
+        let compute_budget = ComputeBudget::new_with_defaults(false, false);
+
+        let result = execute_txn(context, &compute_budget, None)
+            .expect("Transaction execution should succeed");
+        assert!(result.status.is_ok(), "{:?}", result.status);
+
+        let fee_payer_result = result
+            .resulting_accounts
+            .iter()
+            .find(|(k, _)| k == &fee_payer.pubkey())
+            .unwrap();
+        let recipient_result = result
+            .resulting_accounts
+            .iter()
+            .find(|(k, _)| k == &recipient)
+            .unwrap();
+
+        assert_eq!(fee_payer_result.1.lamports, 10_000_000 - transfer_amount);
+        assert_eq!(recipient_result.1.lamports, transfer_amount);
+    }
+
+    #[test]
+    fn test_transfer_insufficient_funds() {
+        let fee_payer = Keypair::new();
+        let recipient = Pubkey::new_unique();
+        let blockhash = Hash::new_unique();
+        let slot = 10u64;
+        let feature_set = FeatureSet::default();
+
+        let mut accounts = vec![
+            (fee_payer.pubkey(), user_account(1000)),
+            (recipient, user_account(0)),
+        ];
+        accounts.extend(create_sysvar_accounts());
+
+        let instruction = system_instruction::transfer(&fee_payer.pubkey(), &recipient, 1_000_000);
+        let message = Message::new(&[instruction], Some(&fee_payer.pubkey()));
+        let transaction = Transaction::new(&[&fee_payer], message, blockhash);
+
+        let context = TxnContext::new(
+            feature_set.clone(),
+            vec![blockhash],
+            slot,
+            accounts,
+            transaction,
+        );
+
+        // Set up the Compute Budget.
+        let compute_budget = ComputeBudget::new_with_defaults(false, false);
+
+        let result = execute_txn(context, &compute_budget, None).unwrap();
+        assert!(result.status.is_err());
+    }
+}

--- a/svm-test-harness/txn/src/lib.rs
+++ b/svm-test-harness/txn/src/lib.rs
@@ -1,0 +1,17 @@
+//! Solana SVM test harness for transaction execution.
+//!
+//! This crate provides an API for Agave's SVM transaction pipeline in order to
+//! execute transactions directly without the runtime.
+
+mod harness;
+
+pub use {
+    harness::execute_txn,
+    solana_compute_budget::compute_budget::ComputeBudget,
+    solana_svm::transaction_processor::ExecutionRecordingConfig,
+    solana_svm_test_harness_fixture as fixture,
+    solana_svm_test_harness_instr::{file, keyed_account},
+};
+
+#[cfg(feature = "fuzz")]
+pub mod fuzz;


### PR DESCRIPTION
#### Problem
In order to prepare for refactoring the rest of programs/sbf tests away from Bank, we need a few more helpers in the svm-test-harness.

#### Summary of Changes
Add a few more builtin program "keyed account" builder helpers for tests.